### PR TITLE
[CHA-2585] feat: add migration guide from stream-chat-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
     <a href="https://github.com/GetStream/getstream-go/issues">Request Feature</a>
 </p>
 
+## Migrating from stream-chat-go?
+
+If you are currently using [`stream-chat-go`](https://github.com/GetStream/stream-chat-go), we have a detailed migration guide with side-by-side code examples for common Chat use cases. See the [Migration Guide](docs/migration-from-stream-chat-go/README.md).
+
 ## **Quick Links**
 
 - [Register](https://getstream.io/chat/trial/) to get an API key for Stream

--- a/docs/migration-from-stream-chat-go/01-setup-and-auth.md
+++ b/docs/migration-from-stream-chat-go/01-setup-and-auth.md
@@ -27,6 +27,8 @@ go get github.com/GetStream/getstream-go/v4
 package main
 
 import (
+	"time"
+
 	stream "github.com/GetStream/stream-chat-go/v8"
 )
 
@@ -48,6 +50,8 @@ func main() {
 package main
 
 import (
+	"time"
+
 	"github.com/GetStream/getstream-go/v4"
 )
 

--- a/docs/migration-from-stream-chat-go/01-setup-and-auth.md
+++ b/docs/migration-from-stream-chat-go/01-setup-and-auth.md
@@ -1,0 +1,149 @@
+# Setup and Authentication
+
+This guide shows how to migrate setup and authentication code from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+
+## Installation
+
+**Before (stream-chat-go):**
+
+```bash
+go get github.com/GetStream/stream-chat-go/v8
+```
+
+**After (getstream-go):**
+
+```bash
+go get github.com/GetStream/getstream-go/v4
+```
+
+**Key changes:**
+- Module path changed from `stream-chat-go/v8` to `getstream-go/v4`
+
+## Client Initialization
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, err := stream.NewClient("your-api-key", "your-api-secret")
+	if err != nil {
+		panic(err)
+	}
+
+	// Or with a custom timeout
+	client, err = stream.NewClient("your-api-key", "your-api-secret",
+		stream.WithTimeout(5*time.Second))
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, err := getstream.NewClient("your-api-key", "your-api-secret")
+	if err != nil {
+		panic(err)
+	}
+
+	// Or with a custom timeout
+	client, err = getstream.NewClient("your-api-key", "your-api-secret",
+		getstream.WithTimeout(5*time.Second))
+}
+```
+
+**Key changes:**
+- Import alias changes from `stream` to `getstream`
+- Same `NewClient(key, secret)` signature, just a different package
+
+## Client from Environment Variables
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	// Reads STREAM_KEY, STREAM_SECRET, STREAM_CHAT_TIMEOUT
+	client, err := stream.NewClientFromEnvVars()
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	// Reads STREAM_API_KEY, STREAM_API_SECRET
+	client, err := getstream.NewClientFromEnvVars()
+}
+```
+
+**Key changes:**
+- Environment variable names changed: `STREAM_KEY` to `STREAM_API_KEY`, `STREAM_SECRET` to `STREAM_API_SECRET`
+
+## Token Generation
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"time"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+
+	// Token with expiration
+	expiry := time.Now().Add(24 * time.Hour)
+	token, err := client.CreateToken("user-123", expiry)
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"time"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+
+	// Token with expiration
+	token, err := client.CreateToken("user-123",
+		getstream.WithExpiration(24*time.Hour))
+}
+```
+
+**Key changes:**
+- `CreateToken` uses functional options (`WithExpiration`) instead of positional `time.Time` arguments
+- Expiration is specified as a duration, not an absolute time

--- a/docs/migration-from-stream-chat-go/01-setup-and-auth.md
+++ b/docs/migration-from-stream-chat-go/01-setup-and-auth.md
@@ -151,3 +151,14 @@ func main() {
 **Key changes:**
 - `CreateToken` uses functional options (`WithExpiration`) instead of positional `time.Time` arguments
 - Expiration is specified as a duration, not an absolute time
+
+## Sub-clients
+
+The new SDK organizes methods into product-specific sub-clients accessed from the main client:
+
+| Sub-client | Access | Description |
+|------------|--------|-------------|
+| Chat | `client.Chat()` | Channels, messages, reactions |
+| Video | `client.Video()` | Calls, call types |
+| Moderation | `client.Moderation()` | Ban, mute, flag |
+| Feeds | `client.Feeds()` | Activity feeds |

--- a/docs/migration-from-stream-chat-go/02-users.md
+++ b/docs/migration-from-stream-chat-go/02-users.md
@@ -1,0 +1,353 @@
+# Users
+
+This guide shows how to migrate user operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+
+## Upsert a Single User
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.UpsertUser(ctx, &stream.User{
+		ID:    "user-123",
+		Name:  "Alice",
+		Image: "https://example.com/alice.jpg",
+		Role:  "user",
+		ExtraData: map[string]interface{}{
+			"country": "NL",
+		},
+	})
+	// resp.User
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.UpdateUsers(ctx, &getstream.UpdateUsersRequest{
+		Users: map[string]getstream.UserRequest{
+			"user-123": {
+				ID:    "user-123",
+				Name:  getstream.PtrTo("Alice"),
+				Image: getstream.PtrTo("https://example.com/alice.jpg"),
+				Role:  getstream.PtrTo("user"),
+				Custom: map[string]any{
+					"country": "NL",
+				},
+			},
+		},
+	})
+	// resp.Data.Users["user-123"]
+}
+```
+
+**Key changes:**
+- `UpsertUser` becomes `UpdateUsers` with a map of `UserRequest` keyed by user ID
+- String fields like `Name`, `Image`, `Role` are pointers; use `getstream.PtrTo()` to set them
+- `ExtraData` becomes `Custom`
+- Response accessed via `resp.Data.Users[id]` instead of `resp.User`
+
+## Upsert Multiple Users
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.UpsertUsers(ctx,
+		&stream.User{ID: "user-1", Name: "Alice"},
+		&stream.User{ID: "user-2", Name: "Bob"},
+	)
+	// resp.Users is map[string]*User
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.UpdateUsers(ctx, &getstream.UpdateUsersRequest{
+		Users: map[string]getstream.UserRequest{
+			"user-1": {ID: "user-1", Name: getstream.PtrTo("Alice")},
+			"user-2": {ID: "user-2", Name: getstream.PtrTo("Bob")},
+		},
+	})
+	// resp.Data.Users is map[string]UserResponse
+}
+```
+
+**Key changes:**
+- `UpsertUsers` (variadic) becomes `UpdateUsers` with a map of `UserRequest`
+- Same endpoint, different calling convention
+
+## Query Users
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.QueryUsers(ctx, &stream.QueryUsersOptions{
+		QueryOption: stream.QueryOption{
+			Filter: map[string]interface{}{
+				"role": map[string]string{"$eq": "admin"},
+			},
+			Limit:  10,
+			Offset: 0,
+		},
+	}, &stream.SortOption{Field: "created_at", Direction: -1})
+	// resp.Users is []*User
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.QueryUsers(ctx, &getstream.QueryUsersRequest{
+		Payload: &getstream.QueryUsersPayload{
+			FilterConditions: map[string]any{
+				"role": map[string]any{"$eq": "admin"},
+			},
+			Limit:  getstream.PtrTo(10),
+			Offset: getstream.PtrTo(0),
+		},
+	})
+	// resp.Data.Users
+}
+```
+
+**Key changes:**
+- Filter and pagination are wrapped in a `Payload` field of type `QueryUsersPayload`
+- `Filter` becomes `FilterConditions`
+- `Limit`/`Offset` are pointers
+- Sort is not a separate argument; it goes inside the payload if needed
+
+## Partial Update User
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	user, err := client.PartialUpdateUser(ctx, stream.PartialUserUpdate{
+		ID: "user-123",
+		Set: map[string]interface{}{
+			"name":    "Alice Updated",
+			"country": "US",
+		},
+		Unset: []string{"image"},
+	})
+	// user is *User
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.UpdateUsersPartial(ctx, &getstream.UpdateUsersPartialRequest{
+		Users: []getstream.UpdateUserPartialRequest{
+			{
+				ID: "user-123",
+				Set: map[string]any{
+					"name":    "Alice Updated",
+					"country": "US",
+				},
+				Unset: []string{"image"},
+			},
+		},
+	})
+	// resp.Data.Users["user-123"]
+}
+```
+
+**Key changes:**
+- `PartialUpdateUser` becomes `UpdateUsersPartial` with a slice of `UpdateUserPartialRequest`
+- Always a batch operation; single user is a slice of one
+- Returns `resp.Data.Users` map instead of a single `*User`
+
+## Deactivate User
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.DeactivateUser(ctx, "user-123",
+		stream.DeactivateUserWithMarkMessagesDeleted())
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.DeactivateUser(ctx, "user-123", &getstream.DeactivateUserRequest{
+		MarkMessagesDeleted: getstream.PtrTo(true),
+	})
+}
+```
+
+**Key changes:**
+- Functional options like `DeactivateUserWithMarkMessagesDeleted()` become fields on a `DeactivateUserRequest` struct
+- User ID is still a positional argument
+
+## Delete Users
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.DeleteUser(ctx, "user-123",
+		stream.DeleteUserWithHardDelete(),
+		stream.DeleteUserWithMarkMessagesDeleted())
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.DeleteUsers(ctx, &getstream.DeleteUsersRequest{
+		UserIds:  []string{"user-123"},
+		User:     getstream.PtrTo("hard"),
+		Messages: getstream.PtrTo("hard"),
+	})
+	// resp.Data.TaskID for async task tracking
+}
+```
+
+**Key changes:**
+- `DeleteUser` (single, sync) becomes `DeleteUsers` (batch, async)
+- Options expressed as string fields (`"hard"` or `"soft"`) instead of functional options
+- Returns a `TaskID` for polling completion

--- a/docs/migration-from-stream-chat-go/03-channels.md
+++ b/docs/migration-from-stream-chat-go/03-channels.md
@@ -1,0 +1,506 @@
+# Channels
+
+This guide shows how to migrate channel operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+
+## Create a Channel
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.CreateChannel(ctx, "messaging", "general", "user-123",
+		&stream.ChannelRequest{
+			Members: []string{"user-123", "user-456"},
+		})
+	// resp.Channel
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	ch := client.Chat().Channel("messaging", "general")
+	resp, err := ch.GetOrCreate(ctx, &getstream.GetOrCreateChannelRequest{
+		Data: &getstream.ChannelInput{
+			CreatedByID: getstream.PtrTo("user-123"),
+			Members: []getstream.ChannelMemberRequest{
+				{UserID: "user-123"},
+				{UserID: "user-456"},
+			},
+		},
+	})
+	// resp.Data.Channel
+}
+```
+
+**Key changes:**
+- `CreateChannel(type, id, creatorID, request)` becomes `client.Chat().Channel(type, id).GetOrCreate(ctx, request)`
+- Members are `[]ChannelMemberRequest` objects instead of `[]string`
+- Creator is set via `CreatedByID` field on `ChannelInput`
+
+## Create a Distinct (1:1) Channel
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	// Empty ID creates a distinct channel based on members
+	resp, err := client.CreateChannel(ctx, "messaging", "", "alice",
+		&stream.ChannelRequest{
+			Members: []string{"alice", "bob"},
+		})
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().GetOrCreateDistinctChannel(ctx, "messaging",
+		&getstream.GetOrCreateDistinctChannelRequest{
+			Data: &getstream.ChannelInput{
+				CreatedByID: getstream.PtrTo("alice"),
+				Members: []getstream.ChannelMemberRequest{
+					{UserID: "alice"},
+					{UserID: "bob"},
+				},
+			},
+		})
+	// resp.Data.Channel
+}
+```
+
+**Key changes:**
+- Distinct channels use a dedicated `GetOrCreateDistinctChannel` method instead of passing an empty ID
+
+## Query Channels
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.QueryChannels(ctx, &stream.QueryOption{
+		Filter: map[string]interface{}{
+			"members": map[string]interface{}{"$in": []string{"user-123"}},
+		},
+		Limit:  10,
+		Offset: 0,
+	}, &stream.SortOption{Field: "created_at", Direction: -1})
+	// resp.Channels is []*Channel
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().QueryChannels(ctx, &getstream.QueryChannelsRequest{
+		FilterConditions: map[string]any{
+			"members": map[string]any{"$in": []string{"user-123"}},
+		},
+	})
+	// resp.Data.Channels
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- `Filter` becomes `FilterConditions` directly on the request (no wrapper `QueryOption`)
+- Sort is a separate field on the request instead of a separate argument
+
+## Add and Remove Members
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	// Add members
+	resp, err := ch.AddMembers(ctx, []string{"user-789", "user-012"})
+
+	// Remove members
+	resp, err = ch.RemoveMembers(ctx, []string{"user-012"}, nil)
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Chat().Channel("messaging", "general")
+
+	// Add members
+	resp, err := ch.Update(ctx, &getstream.UpdateChannelRequest{
+		AddMembers: []getstream.ChannelMemberRequest{
+			{UserID: "user-789"},
+			{UserID: "user-012"},
+		},
+	})
+
+	// Remove members
+	resp, err = ch.Update(ctx, &getstream.UpdateChannelRequest{
+		RemoveMembers: []string{"user-012"},
+	})
+}
+```
+
+**Key changes:**
+- No separate `AddMembers`/`RemoveMembers` methods; use `ch.Update()` with `AddMembers`/`RemoveMembers` fields
+- `AddMembers` takes `[]ChannelMemberRequest` instead of `[]string`
+
+## Update Channel
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	// Full update
+	resp, err := ch.Update(ctx, map[string]interface{}{
+		"color": "blue",
+	}, &stream.Message{Text: "Channel updated"})
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Chat().Channel("messaging", "general")
+
+	// Full update
+	resp, err := ch.Update(ctx, &getstream.UpdateChannelRequest{
+		Data: &getstream.ChannelInputRequest{
+			Custom: map[string]any{"color": "blue"},
+		},
+		Message: &getstream.MessageRequest{
+			Text:   getstream.PtrTo("Channel updated"),
+			UserID: getstream.PtrTo("admin-user"),
+		},
+	})
+}
+```
+
+**Key changes:**
+- Update takes a single `UpdateChannelRequest` struct instead of separate map and message arguments
+- Custom data goes under `Data.Custom`
+- System message is a `MessageRequest` with pointer fields
+
+## Partial Update Channel
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	resp, err := ch.PartialUpdate(ctx, stream.PartialUpdate{
+		Set:   map[string]interface{}{"name": "New Name"},
+		Unset: []string{"description"},
+	})
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Chat().Channel("messaging", "general")
+
+	resp, err := ch.UpdateChannelPartial(ctx, &getstream.UpdateChannelPartialRequest{
+		Set:   map[string]any{"name": "New Name"},
+		Unset: []string{"description"},
+	})
+}
+```
+
+**Key changes:**
+- `PartialUpdate` becomes `UpdateChannelPartial`
+- Same `Set`/`Unset` pattern, wrapped in `UpdateChannelPartialRequest`
+
+## Delete Channel
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	// Soft delete
+	resp, err := ch.Delete(ctx)
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Chat().Channel("messaging", "general")
+
+	// Soft delete
+	resp, err := ch.Delete(ctx, &getstream.DeleteChannelRequest{})
+
+	// Hard delete
+	resp, err = ch.Delete(ctx, &getstream.DeleteChannelRequest{
+		HardDelete: getstream.PtrTo(true),
+	})
+}
+```
+
+**Key changes:**
+- `Delete` requires a `DeleteChannelRequest` argument (can be empty for soft delete)
+- Hard delete is a field on the request instead of separate options
+
+## Batch Delete Channels
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	cids := []string{"messaging:ch1", "messaging:ch2"}
+	resp, err := client.DeleteChannels(ctx, cids, true) // hardDelete = true
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().DeleteChannels(ctx, &getstream.DeleteChannelsRequest{
+		Cids:       []string{"messaging:ch1", "messaging:ch2"},
+		HardDelete: getstream.PtrTo(true),
+	})
+	// resp.Data.TaskID for async task tracking
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- CIDs and hard delete wrapped in `DeleteChannelsRequest`
+
+## Query Members
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	resp, err := ch.QueryMembers(ctx, &stream.QueryOption{
+		Filter: map[string]interface{}{},
+		Limit:  10,
+	})
+	// resp.Members is []*ChannelMember
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().QueryMembers(ctx, &getstream.QueryMembersRequest{
+		Payload: &getstream.QueryMembersPayload{
+			Type:             "messaging",
+			ID:               getstream.PtrTo("general"),
+			FilterConditions: map[string]any{},
+		},
+	})
+	// resp.Data.Members
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` instead of the channel object
+- Channel type and ID are fields on the `QueryMembersPayload` instead of being implicit from the channel object

--- a/docs/migration-from-stream-chat-go/04-messages-and-reactions.md
+++ b/docs/migration-from-stream-chat-go/04-messages-and-reactions.md
@@ -1,0 +1,480 @@
+# Messages and Reactions
+
+This guide shows how to migrate message and reaction operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+
+## Send a Message
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	resp, err := ch.SendMessage(ctx, &stream.Message{
+		Text: "Hello world",
+	}, "user-123")
+	// resp.Message
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Chat().Channel("messaging", "general")
+
+	resp, err := ch.SendMessage(ctx, &getstream.SendMessageRequest{
+		Message: getstream.MessageRequest{
+			Text:   getstream.PtrTo("Hello world"),
+			UserID: getstream.PtrTo("user-123"),
+		},
+	})
+	// resp.Data.Message
+}
+```
+
+**Key changes:**
+- User ID moves from a separate argument into `MessageRequest.UserID`
+- Message content is wrapped in `SendMessageRequest` > `MessageRequest`
+- `Text` is a pointer field; use `getstream.PtrTo()`
+- Response accessed via `resp.Data.Message`
+
+## Send a Thread Reply
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	resp, err := ch.SendMessage(ctx, &stream.Message{
+		Text:     "This is a reply",
+		ParentID: "parent-message-id",
+	}, "user-123")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Chat().Channel("messaging", "general")
+
+	resp, err := ch.SendMessage(ctx, &getstream.SendMessageRequest{
+		Message: getstream.MessageRequest{
+			Text:     getstream.PtrTo("This is a reply"),
+			ParentID: getstream.PtrTo("parent-message-id"),
+			UserID:   getstream.PtrTo("user-123"),
+		},
+	})
+}
+```
+
+**Key changes:**
+- Same pattern as regular messages; `ParentID` is a pointer field on `MessageRequest`
+
+## Get a Message
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.GetMessage(ctx, "message-id")
+	// resp.Message
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().GetMessage(ctx, "message-id", &getstream.GetMessageRequest{})
+	// resp.Data.Message
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- Requires a `GetMessageRequest` argument (can be empty)
+
+## Update a Message
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.UpdateMessage(ctx, &stream.Message{
+		Text: "Updated text",
+	}, "message-id")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().UpdateMessage(ctx, "message-id", &getstream.UpdateMessageRequest{
+		Message: getstream.MessageRequest{
+			Text:   getstream.PtrTo("Updated text"),
+			UserID: getstream.PtrTo("user-123"),
+		},
+	})
+}
+```
+
+**Key changes:**
+- Message ID is a positional argument, not part of the message struct
+- Message content wrapped in `UpdateMessageRequest` > `MessageRequest`
+
+## Partial Update a Message
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.PartialUpdateMessage(ctx, "message-id", &stream.MessagePartialUpdateRequest{
+		PartialUpdate: stream.PartialUpdate{
+			Set: map[string]interface{}{
+				"text":   "New text",
+				"pinned": true,
+			},
+			Unset: []string{"attachments"},
+		},
+		UserID: "user-123",
+	})
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().UpdateMessagePartial(ctx, "message-id",
+		&getstream.UpdateMessagePartialRequest{
+			Set: map[string]any{
+				"priority": "high",
+				"status":   "reviewed",
+			},
+			Unset:  []string{"old_field"},
+			UserID: getstream.PtrTo("user-123"),
+		})
+}
+```
+
+**Key changes:**
+- `PartialUpdateMessage` becomes `UpdateMessagePartial`
+- `Set`/`Unset` are directly on the request (no nested `PartialUpdate` struct)
+- `UserID` is a pointer
+
+## Delete a Message
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	// Soft delete
+	resp, err := client.DeleteMessage(ctx, "message-id")
+
+	// Hard delete
+	resp, err = client.DeleteMessage(ctx, "message-id", stream.DeleteMessageWithHard())
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	// Soft delete
+	resp, err := client.Chat().DeleteMessage(ctx, "message-id", &getstream.DeleteMessageRequest{})
+
+	// Hard delete
+	resp, err = client.Chat().DeleteMessage(ctx, "message-id", &getstream.DeleteMessageRequest{
+		Hard: getstream.PtrTo(true),
+	})
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- Functional options replaced by fields on `DeleteMessageRequest`
+
+## Send a Reaction
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.SendReaction(ctx, &stream.Reaction{
+		Type: "like",
+	}, "message-id", "user-123")
+	// resp.Reaction
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().SendReaction(ctx, "message-id", &getstream.SendReactionRequest{
+		Reaction: getstream.ReactionRequest{
+			Type:   "like",
+			UserID: getstream.PtrTo("user-123"),
+		},
+	})
+	// resp.Data.Reaction
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- Message ID is a positional argument; user ID moves into `ReactionRequest.UserID`
+- Reaction wrapped in `SendReactionRequest` > `ReactionRequest`
+
+## List Reactions
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.GetReactions(ctx, "message-id", map[string][]string{
+		"limit":  {"10"},
+		"offset": {"0"},
+	})
+	// resp.Reactions
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().GetReactions(ctx, "message-id", &getstream.GetReactionsRequest{
+		Limit:  getstream.PtrTo(10),
+		Offset: getstream.PtrTo(0),
+	})
+	// resp.Data.Reactions
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- Query params replaced by typed fields on `GetReactionsRequest`
+
+## Delete a Reaction
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.DeleteReaction(ctx, "message-id", "like", "user-123")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().DeleteReaction(ctx, "message-id", "like",
+		&getstream.DeleteReactionRequest{
+			UserID: getstream.PtrTo("user-123"),
+		})
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- User ID moves from a positional argument into `DeleteReactionRequest.UserID`

--- a/docs/migration-from-stream-chat-go/05-moderation.md
+++ b/docs/migration-from-stream-chat-go/05-moderation.md
@@ -1,0 +1,445 @@
+# Moderation
+
+This guide shows how to migrate moderation operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+
+## Add Moderators
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	resp, err := ch.AddModerators(ctx, "user-123", "user-456")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Chat().Channel("messaging", "general")
+
+	resp, err := ch.Update(ctx, &getstream.UpdateChannelRequest{
+		AddModerators: []string{"user-123", "user-456"},
+	})
+}
+```
+
+**Key changes:**
+- No dedicated `AddModerators` method; use `ch.Update()` with `AddModerators` field
+- `DemoteModerators` is also a field on `UpdateChannelRequest`
+
+## Ban User (App Level)
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.BanUser(ctx, "target-user", "moderator-user",
+		stream.BanWithReason("Spam"),
+		stream.BanWithExpiration(60))
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Moderation().Ban(ctx, &getstream.BanRequest{
+		TargetUserID: "target-user",
+		BannedByID:   getstream.PtrTo("moderator-user"),
+		Reason:       getstream.PtrTo("Spam"),
+		Timeout:      getstream.PtrTo(60),
+	})
+}
+```
+
+**Key changes:**
+- Called on `client.Moderation()` sub-client instead of the root client
+- Functional options replaced by fields on `BanRequest`
+- `BanWithExpiration` becomes `Timeout`
+
+## Ban User (Channel Level)
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+	ch := client.Channel("messaging", "general")
+
+	resp, err := ch.BanUser(ctx, "target-user", "moderator-user",
+		stream.BanWithReason("Inappropriate content"))
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Moderation().Ban(ctx, &getstream.BanRequest{
+		TargetUserID: "target-user",
+		BannedByID:   getstream.PtrTo("moderator-user"),
+		ChannelCid:   getstream.PtrTo("messaging:general"),
+		Reason:       getstream.PtrTo("Inappropriate content"),
+	})
+}
+```
+
+**Key changes:**
+- No channel-level `BanUser` method; use `client.Moderation().Ban()` with `ChannelCid` field
+- Channel CID format is `type:id` (e.g., `messaging:general`)
+
+## Unban User
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	// App-level unban
+	resp, err := client.UnBanUser(ctx, "target-user")
+
+	// Channel-level unban
+	ch := client.Channel("messaging", "general")
+	resp, err = ch.UnBanUser(ctx, "target-user")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	// App-level unban
+	resp, err := client.Moderation().Unban(ctx, &getstream.UnbanRequest{
+		TargetUserID: "target-user",
+	})
+
+	// Channel-level unban
+	resp, err = client.Moderation().Unban(ctx, &getstream.UnbanRequest{
+		TargetUserID: "target-user",
+		ChannelCid:   getstream.PtrTo("messaging:general"),
+	})
+}
+```
+
+**Key changes:**
+- Both app-level and channel-level unbans use `client.Moderation().Unban()`
+- Channel scope specified via `ChannelCid` field
+
+## Shadow Ban
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	// App-level shadow ban
+	resp, err := client.ShadowBan(ctx, "target-user", "moderator-user")
+
+	// Channel-level shadow ban
+	ch := client.Channel("messaging", "general")
+	resp, err = ch.ShadowBan(ctx, "target-user", "moderator-user")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	// App-level shadow ban
+	resp, err := client.Moderation().Ban(ctx, &getstream.BanRequest{
+		TargetUserID: "target-user",
+		BannedByID:   getstream.PtrTo("moderator-user"),
+		Shadow:       getstream.PtrTo(true),
+	})
+
+	// Channel-level shadow ban
+	resp, err = client.Moderation().Ban(ctx, &getstream.BanRequest{
+		TargetUserID: "target-user",
+		BannedByID:   getstream.PtrTo("moderator-user"),
+		ChannelCid:   getstream.PtrTo("messaging:general"),
+		Shadow:       getstream.PtrTo(true),
+	})
+}
+```
+
+**Key changes:**
+- No separate `ShadowBan` method; use `Ban()` with `Shadow: true`
+
+## Query Banned Users
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.QueryBannedUsers(ctx, &stream.QueryBannedUsersOptions{
+		QueryOption: stream.QueryOption{
+			Filter: map[string]interface{}{
+				"channel_cid": "messaging:general",
+			},
+			Limit: 10,
+		},
+	})
+	// resp.Bans
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Chat().QueryBannedUsers(ctx, &getstream.QueryBannedUsersRequest{
+		Payload: &getstream.QueryBannedUsersPayload{
+			FilterConditions: map[string]any{
+				"channel_cid": "messaging:general",
+			},
+		},
+	})
+	// resp.Data.Bans
+}
+```
+
+**Key changes:**
+- Called on `client.Chat()` sub-client
+- Filter wrapped in `Payload.FilterConditions`
+
+## Mute User
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.MuteUser(ctx, "target-user", "moderator-user",
+		stream.MuteWithExpiration(60))
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Moderation().Mute(ctx, &getstream.MuteRequest{
+		TargetIds: []string{"target-user"},
+		UserID:    getstream.PtrTo("moderator-user"),
+		Timeout:   getstream.PtrTo(60),
+	})
+}
+```
+
+**Key changes:**
+- Called on `client.Moderation()` sub-client
+- `MuteUser` becomes `Mute` with `MuteRequest`
+- `TargetIds` is a slice, allowing batch muting
+- Expiration specified via `Timeout` (minutes)
+
+## Unmute User
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.UnmuteUser(ctx, "target-user", "moderator-user")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.Moderation().Unmute(ctx, &getstream.UnmuteRequest{
+		TargetIds: []string{"target-user"},
+		UserID:    getstream.PtrTo("moderator-user"),
+	})
+}
+```
+
+**Key changes:**
+- Called on `client.Moderation()` sub-client
+- `UnmuteUser` becomes `Unmute` with `UnmuteRequest`
+- `TargetIds` is a slice, allowing batch unmuting
+
+## Method Mapping Summary
+
+| Legacy (stream-chat-go) | New (getstream-go) |
+|---|---|
+| `ch.AddModerators(ctx, ids...)` | `ch.Update(ctx, &UpdateChannelRequest{AddModerators: ids})` |
+| `ch.DemoteModerators(ctx, ids...)` | `ch.Update(ctx, &UpdateChannelRequest{DemoteModerators: ids})` |
+| `client.BanUser(ctx, target, by, opts...)` | `client.Moderation().Ban(ctx, &BanRequest{...})` |
+| `ch.BanUser(ctx, target, by, opts...)` | `client.Moderation().Ban(ctx, &BanRequest{ChannelCid: ...})` |
+| `client.UnBanUser(ctx, target, opts...)` | `client.Moderation().Unban(ctx, &UnbanRequest{...})` |
+| `client.ShadowBan(ctx, target, by)` | `client.Moderation().Ban(ctx, &BanRequest{Shadow: true})` |
+| `client.MuteUser(ctx, target, by, opts...)` | `client.Moderation().Mute(ctx, &MuteRequest{...})` |
+| `client.UnmuteUser(ctx, target, by)` | `client.Moderation().Unmute(ctx, &UnmuteRequest{...})` |
+| `client.QueryBannedUsers(ctx, opts)` | `client.Chat().QueryBannedUsers(ctx, &QueryBannedUsersRequest{...})` |

--- a/docs/migration-from-stream-chat-go/06-devices.md
+++ b/docs/migration-from-stream-chat-go/06-devices.md
@@ -1,0 +1,212 @@
+# Devices
+
+This guide shows how to migrate device (push notification) operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+
+## Add a Device
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.AddDevice(ctx, &stream.Device{
+		ID:           "device-token-123",
+		UserID:       "user-123",
+		PushProvider: stream.PushProviderFirebase,
+	})
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.CreateDevice(ctx, &getstream.CreateDeviceRequest{
+		ID:           "device-token-123",
+		UserID:       getstream.PtrTo("user-123"),
+		PushProvider: "firebase",
+	})
+}
+```
+
+**Key changes:**
+- `AddDevice` becomes `CreateDevice`
+- `Device` struct becomes `CreateDeviceRequest`
+- `UserID` is a pointer field
+- `PushProvider` is a plain string (`"firebase"`, `"apn"`) instead of a typed constant
+
+## Add an APN Device
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.AddDevice(ctx, &stream.Device{
+		ID:           "apn-device-token",
+		UserID:       "user-123",
+		PushProvider: stream.PushProviderAPN,
+	})
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.CreateDevice(ctx, &getstream.CreateDeviceRequest{
+		ID:           "apn-device-token",
+		UserID:       getstream.PtrTo("user-123"),
+		PushProvider: "apn",
+	})
+}
+```
+
+**Key changes:**
+- `PushProviderAPN` constant becomes the string `"apn"`
+
+## List Devices
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.GetDevices(ctx, "user-123")
+	// resp.Devices is []*Device
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.ListDevices(ctx, &getstream.ListDevicesRequest{
+		UserID: getstream.PtrTo("user-123"),
+	})
+	// resp.Data.Devices
+}
+```
+
+**Key changes:**
+- `GetDevices` becomes `ListDevices`
+- User ID moves from a positional argument into `ListDevicesRequest.UserID`
+- Response accessed via `resp.Data.Devices`
+
+## Delete a Device
+
+**Before (stream-chat-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.DeleteDevice(ctx, "user-123", "device-token-123")
+}
+```
+
+**After (getstream-go):**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("your-api-key", "your-api-secret")
+	ctx := context.Background()
+
+	resp, err := client.DeleteDevice(ctx, &getstream.DeleteDeviceRequest{
+		ID:     "device-token-123",
+		UserID: getstream.PtrTo("user-123"),
+	})
+}
+```
+
+**Key changes:**
+- Positional arguments become fields on `DeleteDeviceRequest`
+- `UserID` is a pointer field
+
+## Method Mapping Summary
+
+| Legacy (stream-chat-go) | New (getstream-go) |
+|---|---|
+| `client.AddDevice(ctx, &Device{...})` | `client.CreateDevice(ctx, &CreateDeviceRequest{...})` |
+| `client.GetDevices(ctx, userID)` | `client.ListDevices(ctx, &ListDevicesRequest{UserID: ...})` |
+| `client.DeleteDevice(ctx, userID, deviceID)` | `client.DeleteDevice(ctx, &DeleteDeviceRequest{ID: ..., UserID: ...})` |

--- a/docs/migration-from-stream-chat-go/README.md
+++ b/docs/migration-from-stream-chat-go/README.md
@@ -1,0 +1,88 @@
+# Migrating from stream-chat-go to getstream-go
+
+## Why Migrate?
+
+- `getstream-go` is the actively developed, long-term-supported SDK
+- Covers Chat, Video, Moderation, and Feeds in a single package
+- Strongly typed models generated from the official OpenAPI spec
+- `stream-chat-go` will enter maintenance mode (critical fixes only)
+
+## Key Differences
+
+| Aspect | stream-chat-go | getstream-go |
+|--------|----------------|--------------|
+| Import | `github.com/GetStream/stream-chat-go/v8` | `github.com/GetStream/getstream-go/v4` |
+| Env vars | `STREAM_KEY`, `STREAM_SECRET` | `STREAM_API_KEY`, `STREAM_API_SECRET` |
+| Client init | `stream.NewClient(key, secret)` | `getstream.NewClient(key, secret)` |
+| Sub-clients | All methods on root client | `client.Chat()`, `client.Moderation()`, `client.Video()` |
+| Channel object | `client.Channel(type, id)` | `client.Chat().Channel(type, id)` |
+| Models | Flat structs with `ExtraData` | Generated request/response types with `Custom` maps |
+| Optional fields | Value types or functional options | Pointers via `getstream.PtrTo()` |
+| Members | `[]string` of user IDs | `[]ChannelMemberRequest` structs |
+
+## Quick Example
+
+**Before:**
+
+```go
+package main
+
+import (
+	"context"
+
+	stream "github.com/GetStream/stream-chat-go/v8"
+)
+
+func main() {
+	client, _ := stream.NewClient("key", "secret")
+	ctx := context.Background()
+
+	ch := client.Channel("messaging", "general")
+	resp, err := ch.SendMessage(ctx, &stream.Message{
+		Text: "Hello!",
+	}, "user-123")
+}
+```
+
+**After:**
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/GetStream/getstream-go/v4"
+)
+
+func main() {
+	client, _ := getstream.NewClient("key", "secret")
+	ctx := context.Background()
+
+	ch := client.Chat().Channel("messaging", "general")
+	resp, err := ch.SendMessage(ctx, &getstream.SendMessageRequest{
+		Message: getstream.MessageRequest{
+			Text:   getstream.PtrTo("Hello!"),
+			UserID: getstream.PtrTo("user-123"),
+		},
+	})
+}
+```
+
+## Migration Guides by Topic
+
+| # | Topic | File |
+|---|-------|------|
+| 1 | [Setup and Authentication](01-setup-and-auth.md) | Client init, tokens |
+| 2 | [Users](02-users.md) | Upsert, query, update, delete |
+| 3 | [Channels](03-channels.md) | Create, query, members, update |
+| 4 | [Messages and Reactions](04-messages-and-reactions.md) | Send, reply, react |
+| 5 | [Moderation](05-moderation.md) | Ban, mute, moderators |
+| 6 | [Devices](06-devices.md) | Push device management |
+
+## Notes
+
+- `stream-chat-go` is not going away. Your existing integration will keep working.
+- The new SDK uses typed request structs with pointer fields for optional values.
+- Use `getstream.PtrTo(value)` to convert any value to a pointer for optional fields.
+- If you find a use case missing from this guide, please open an issue.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes (new markdown files and a README link) with no runtime or API behavior impact.
> 
> **Overview**
> Adds a new `docs/migration-from-stream-chat-go` guide (setup/auth, users, channels, messages/reactions, moderation, devices) with side-by-side `stream-chat-go` vs `getstream-go` examples and a method-mapping overview.
> 
> Updates `README.md` to prominently link to this migration guide for existing `stream-chat-go` users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5838a1075c07fa5188e954ffd3024844665159a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->