### PR TITLE
[FEEDS-1372] Regenerate OpenAPI SDK (getstream-go)

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -15,10 +15,27 @@ func NewChatClient(client *Client) *ChatClient {
 	}
 }
 
+// Creates a campaign
+func (c *ChatClient) CreateCampaign(ctx context.Context, request *CreateCampaignRequest) (*StreamResponse[CreateCampaignResponse], error) {
+	var result CreateCampaignResponse
+	res, err := MakeRequest[CreateCampaignRequest, CreateCampaignResponse](c.client, ctx, "POST", "/api/v2/chat/campaigns", nil, request, &result, nil)
+	return res, err
+}
+
 // Query campaigns with filter query
 func (c *ChatClient) QueryCampaigns(ctx context.Context, request *QueryCampaignsRequest) (*StreamResponse[QueryCampaignsResponse], error) {
 	var result QueryCampaignsResponse
 	res, err := MakeRequest[QueryCampaignsRequest, QueryCampaignsResponse](c.client, ctx, "POST", "/api/v2/chat/campaigns/query", nil, request, &result, nil)
+	return res, err
+}
+
+// Delete campaign
+func (c *ChatClient) DeleteCampaign(ctx context.Context, id string, request *DeleteCampaignRequest) (*StreamResponse[DeleteCampaignResponse], error) {
+	var result DeleteCampaignResponse
+	pathParams := map[string]string{
+		"id": id,
+	}
+	res, err := MakeRequest[any, DeleteCampaignResponse](c.client, ctx, "DELETE", "/api/v2/chat/campaigns/{id}", nil, nil, &result, pathParams)
 	return res, err
 }
 
@@ -30,6 +47,16 @@ func (c *ChatClient) GetCampaign(ctx context.Context, id string, request *GetCam
 	}
 	params := extractQueryParams(request)
 	res, err := MakeRequest[any, GetCampaignResponse](c.client, ctx, "GET", "/api/v2/chat/campaigns/{id}", params, nil, &result, pathParams)
+	return res, err
+}
+
+// Updates a campaign
+func (c *ChatClient) UpdateCampaign(ctx context.Context, id string, request *UpdateCampaignRequest) (*StreamResponse[CampaignResponse], error) {
+	var result CampaignResponse
+	pathParams := map[string]string{
+		"id": id,
+	}
+	res, err := MakeRequest[UpdateCampaignRequest, CampaignResponse](c.client, ctx, "PUT", "/api/v2/chat/campaigns/{id}", nil, request, &result, pathParams)
 	return res, err
 }
 
@@ -92,6 +119,13 @@ func (c *ChatClient) MarkDelivered(ctx context.Context, request *MarkDeliveredRe
 	var result MarkDeliveredResponse
 	params := extractQueryParams(request)
 	res, err := MakeRequest[MarkDeliveredRequest, MarkDeliveredResponse](c.client, ctx, "POST", "/api/v2/chat/channels/delivered", params, request, &result, nil)
+	return res, err
+}
+
+// Query channels grouped into predefined buckets. Only available for enterprise apps.
+func (c *ChatClient) GroupedQueryChannels(ctx context.Context, request *GroupedQueryChannelsRequest) (*StreamResponse[GroupedQueryChannelsResponse], error) {
+	var result GroupedQueryChannelsResponse
+	res, err := MakeRequest[GroupedQueryChannelsRequest, GroupedQueryChannelsResponse](c.client, ctx, "POST", "/api/v2/chat/channels/grouped", nil, request, &result, nil)
 	return res, err
 }
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestChatCreateCampaign(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Chat().CreateCampaign(context.Background(), &getstream.CreateCampaignRequest{})
+	require.NoError(t, err)
+}
 func TestChatQueryCampaigns(t *testing.T) {
 	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
 	require.NoError(t, err)
@@ -16,11 +23,25 @@ func TestChatQueryCampaigns(t *testing.T) {
 	_, err = client.Chat().QueryCampaigns(context.Background(), &getstream.QueryCampaignsRequest{})
 	require.NoError(t, err)
 }
+func TestChatDeleteCampaign(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Chat().DeleteCampaign(context.Background(), "", &getstream.DeleteCampaignRequest{})
+	require.NoError(t, err)
+}
 func TestChatGetCampaign(t *testing.T) {
 	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
 	require.NoError(t, err)
 
 	_, err = client.Chat().GetCampaign(context.Background(), "", &getstream.GetCampaignRequest{})
+	require.NoError(t, err)
+}
+func TestChatUpdateCampaign(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Chat().UpdateCampaign(context.Background(), "", &getstream.UpdateCampaignRequest{})
 	require.NoError(t, err)
 }
 func TestChatStartCampaign(t *testing.T) {
@@ -63,6 +84,13 @@ func TestChatMarkDelivered(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.Chat().MarkDelivered(context.Background(), &getstream.MarkDeliveredRequest{})
+	require.NoError(t, err)
+}
+func TestChatGroupedQueryChannels(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Chat().GroupedQueryChannels(context.Background(), &getstream.GroupedQueryChannelsRequest{})
 	require.NoError(t, err)
 }
 func TestChatMarkChannelsRead(t *testing.T) {

--- a/feeds-v3.go
+++ b/feeds-v3.go
@@ -217,7 +217,7 @@ func (c *FeedsClient) UpdateActivity(ctx context.Context, id string, request *Up
 	return res, err
 }
 
-// Restores a soft-deleted activity by its ID. Only the activity owner can restore their own activities.
+// Restores a soft-deleted, moderation-removed, or shadow-blocked activity by its ID. Deleted activities can be restored by the owner (client-side). Moderation-blocked activities can only be restored server-side.
 func (c *FeedsClient) RestoreActivity(ctx context.Context, id string, request *RestoreActivityRequest) (*StreamResponse[RestoreActivityResponse], error) {
 	var result RestoreActivityResponse
 	pathParams := map[string]string{
@@ -455,7 +455,7 @@ func (c *FeedsClient) GetCommentReplies(ctx context.Context, id string, request 
 	return res, err
 }
 
-// Restores a soft-deleted comment by its ID. The comment and all its descendants are restored. Requires moderator permissions.
+// Restores a soft-deleted, moderation-removed, or shadow-blocked comment by its ID. The comment and all its descendants are restored. Deleted comments can be restored client-side. Moderation-blocked comments can only be restored server-side.
 func (c *FeedsClient) RestoreComment(ctx context.Context, id string, request *RestoreCommentRequest) (*StreamResponse[RestoreCommentResponse], error) {
 	var result RestoreCommentResponse
 	pathParams := map[string]string{
@@ -547,6 +547,17 @@ func (c *FeedsClient) PinActivity(ctx context.Context, feedGroupID string, feedI
 		"activity_id":   activityID,
 	}
 	res, err := MakeRequest[PinActivityRequest, PinActivityResponse](c.client, ctx, "POST", "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin", nil, request, &result, pathParams)
+	return res, err
+}
+
+// Changes the visibility of an existing feed. Follow reconciliation (rewriting pending follows on loosening, or removing disallowed follows/members on tightening) runs asynchronously in the background; the response returns optimistically with the intended visibility.
+func (c *FeedsClient) ChangeFeedVisibility(ctx context.Context, feedGroupID string, feedID string, request *ChangeFeedVisibilityRequest) (*StreamResponse[ChangeFeedVisibilityResponse], error) {
+	var result ChangeFeedVisibilityResponse
+	pathParams := map[string]string{
+		"feed_group_id": feedGroupID,
+		"feed_id":       feedID,
+	}
+	res, err := MakeRequest[ChangeFeedVisibilityRequest, ChangeFeedVisibilityResponse](c.client, ctx, "POST", "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/change_visibility", nil, request, &result, pathParams)
 	return res, err
 }
 
@@ -878,6 +889,13 @@ func (c *FeedsClient) UpdateMembershipLevel(ctx context.Context, id string, requ
 		"id": id,
 	}
 	res, err := MakeRequest[UpdateMembershipLevelRequest, UpdateMembershipLevelResponse](c.client, ctx, "PATCH", "/api/v2/feeds/membership_levels/{id}", nil, request, &result, pathParams)
+	return res, err
+}
+
+// Queries revision history for activities and comments
+func (c *FeedsClient) QueryRevisionHistory(ctx context.Context, request *QueryRevisionHistoryRequest) (*StreamResponse[QueryRevisionHistoryResponse], error) {
+	var result QueryRevisionHistoryResponse
+	res, err := MakeRequest[QueryRevisionHistoryRequest, QueryRevisionHistoryResponse](c.client, ctx, "POST", "/api/v2/feeds/revisions/query", nil, request, &result, nil)
 	return res, err
 }
 

--- a/feeds.go
+++ b/feeds.go
@@ -41,6 +41,10 @@ func (c *Feeds) PinActivity(ctx context.Context, activityID string, request *Pin
 	return c.client.PinActivity(ctx, c.feedType, c.feedID, activityID, request)
 }
 
+func (c *Feeds) ChangeFeedVisibility(ctx context.Context, request *ChangeFeedVisibilityRequest) (*StreamResponse[ChangeFeedVisibilityResponse], error) {
+	return c.client.ChangeFeedVisibility(ctx, c.feedType, c.feedID, request)
+}
+
 func (c *Feeds) UpdateFeedMembers(ctx context.Context, request *UpdateFeedMembersRequest) (*StreamResponse[UpdateFeedMembersResponse], error) {
 	return c.client.UpdateFeedMembers(ctx, c.feedType, c.feedID, request)
 }

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -387,6 +387,13 @@ func TestFeedsPinActivity(t *testing.T) {
 	_, err = client.Feeds().PinActivity(context.Background(), "", "", "", &getstream.PinActivityRequest{})
 	require.NoError(t, err)
 }
+func TestFeedsChangeFeedVisibility(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Feeds().ChangeFeedVisibility(context.Background(), "", "", &getstream.ChangeFeedVisibilityRequest{})
+	require.NoError(t, err)
+}
 func TestFeedsUpdateFeedMembers(t *testing.T) {
 	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
 	require.NoError(t, err)
@@ -644,6 +651,13 @@ func TestFeedsUpdateMembershipLevel(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.Feeds().UpdateMembershipLevel(context.Background(), "", &getstream.UpdateMembershipLevelRequest{})
+	require.NoError(t, err)
+}
+func TestFeedsQueryRevisionHistory(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Feeds().QueryRevisionHistory(context.Background(), &getstream.QueryRevisionHistoryRequest{})
 	require.NoError(t, err)
 }
 func TestFeedsQueryFeedsUsageStats(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -124,6 +124,8 @@ type ActionLogResponse struct {
 	ID string `json:"id"`
 	// Reason for the moderation action
 	Reason string `json:"reason"`
+	// Classification of who triggered the action (e.g. user, moderator, automod, api_integration)
+	ReporterType string `json:"reporter_type"`
 	// ID of the user who was the target of the action
 	TargetUserID string `json:"target_user_id"`
 	// ID of the user who performed the action
@@ -561,7 +563,7 @@ type ActivitySelectorConfig struct {
 	CutoffTime *string `json:"cutoff_time,omitempty"`
 	// Flexible relative time window for activity selection (e.g., '1h', '3d', '1y'). Activities older than this duration will be filtered out. Cannot be used together with cutoff_time
 	CutoffWindow *string `json:"cutoff_window,omitempty"`
-	// Minimum popularity threshold
+	// Minimum popularity threshold. For the 'popular' selector, omit to use the default (5); values below 1 are rejected
 	MinPopularity *int `json:"min_popularity,omitempty"`
 	// Sort parameters for activity selection
 	Sort []SortParamRequest `json:"sort,omitempty"`
@@ -577,7 +579,7 @@ type ActivitySelectorConfigResponse struct {
 	CutoffTime *Timestamp `json:"cutoff_time,omitempty"`
 	// Flexible relative time window for activity selection (e.g., '1h', '3d', '1y')
 	CutoffWindow *string `json:"cutoff_window,omitempty"`
-	// Minimum popularity threshold
+	// Minimum popularity threshold. For the 'popular' selector, values below 1 are normalized to the default (5) at read time.
 	MinPopularity *int `json:"min_popularity,omitempty"`
 	// Sort parameters for activity selection
 	Sort []SortParamRequest `json:"sort,omitempty"`
@@ -746,6 +748,7 @@ type AppResponseFields struct {
 	DisableAuthChecks                     bool                            `json:"disable_auth_checks"`
 	DisablePermissionsChecks              bool                            `json:"disable_permissions_checks"`
 	EnforceUniqueUsernames                string                          `json:"enforce_unique_usernames"`
+	FeedAuditLogsEnabled                  bool                            `json:"feed_audit_logs_enabled"`
 	GuestUserCreationDisabled             bool                            `json:"guest_user_creation_disabled"`
 	ID                                    int                             `json:"id"`
 	ImageModerationEnabled                bool                            `json:"image_moderation_enabled"`
@@ -1214,6 +1217,11 @@ type BodyguardImageAnalysisConfig struct {
 	Rules []BodyguardRule `json:"rules,omitempty"`
 }
 
+type BodyguardProfileSummary struct {
+	Name        string  `json:"name"`
+	DisplayName *string `json:"display_name,omitempty"`
+}
+
 type BodyguardRule struct {
 	Label         string                  `json:"label"`
 	Action        *string                 `json:"action,omitempty"`
@@ -1366,10 +1374,22 @@ type BrowserDataResponse struct {
 	Version *string `json:"version,omitempty"`
 }
 
+type BulkDeleteActionConfigResponse struct {
+	// Number of action configs deleted
+	Deleted  int    `json:"deleted"`
+	Duration string `json:"duration"`
+}
+
 type BulkImageModerationResponse struct {
 	Duration string `json:"duration"`
 	// ID of the task for processing the bulk image moderation
 	TaskID string `json:"task_id"`
+}
+
+type BulkUpsertActionConfigResponse struct {
+	Duration string `json:"duration"`
+	// The created or updated action configs in the same order as the request
+	ActionConfigs []ModerationActionConfigResponse `json:"action_configs"`
 }
 
 type BypassActionRequest struct {
@@ -2516,11 +2536,11 @@ type CampaignChannelMember struct {
 
 type CampaignChannelTemplate struct {
 	Type            string                  `json:"type"`
-	Custom          map[string]any          `json:"custom"`
 	ID              *string                 `json:"id,omitempty"`
 	Team            *string                 `json:"team,omitempty"`
 	Members         []string                `json:"members,omitempty"`
 	MembersTemplate []CampaignChannelMember `json:"members_template,omitempty"`
+	Custom          map[string]any          `json:"custom,omitempty"`
 }
 
 type CampaignCompletedEvent struct {
@@ -2536,11 +2556,11 @@ func (e *CampaignCompletedEvent) GetEventType() string {
 }
 
 type CampaignMessageTemplate struct {
-	PollID      string         `json:"poll_id"`
-	Searchable  bool           `json:"searchable"`
 	Text        string         `json:"text"`
-	Attachments []Attachment   `json:"attachments"`
-	Custom      map[string]any `json:"custom"`
+	PollID      *string        `json:"poll_id,omitempty"`
+	Searchable  *bool          `json:"searchable,omitempty"`
+	Attachments []Attachment   `json:"attachments,omitempty"`
+	Custom      map[string]any `json:"custom,omitempty"`
 }
 
 type CampaignResponse struct {
@@ -2589,6 +2609,11 @@ type CampaignStatsResponse struct {
 	StatsStartedAt       Timestamp `json:"stats_started_at"`
 	StatsUsersRead       int       `json:"stats_users_read"`
 	StatsUsersSent       int       `json:"stats_users_sent"`
+}
+
+type ChangeFeedVisibilityResponse struct {
+	Duration string       `json:"duration"`
+	Feed     FeedResponse `json:"feed"`
 }
 
 type ChannelBatchCompletedEvent struct {
@@ -3296,6 +3321,46 @@ type ChatActivityStatsResponse struct {
 	Messages *MessageStatsResponse `json:"Messages,omitempty"`
 }
 
+type ChatMessageResponse struct {
+	Cid                  string               `json:"cid"`
+	CreatedAt            Timestamp            `json:"created_at"`
+	DeletedReplyCount    int                  `json:"deleted_reply_count"`
+	Html                 string               `json:"html"`
+	ID                   string               `json:"id"`
+	MentionedChannel     bool                 `json:"mentioned_channel"`
+	MentionedHere        bool                 `json:"mentioned_here"`
+	Pinned               bool                 `json:"pinned"`
+	ReplyCount           int                  `json:"reply_count"`
+	Shadowed             bool                 `json:"shadowed"`
+	Silent               bool                 `json:"silent"`
+	Text                 string               `json:"text"`
+	UpdatedAt            Timestamp            `json:"updated_at"`
+	Type                 string               `json:"type"`
+	Attachments          []any                `json:"attachments"`
+	LatestReactions      []any                `json:"latest_reactions"`
+	MentionedUsers       []UserResponse       `json:"mentioned_users"`
+	OwnReactions         []any                `json:"own_reactions"`
+	RestrictedVisibility []string             `json:"restricted_visibility"`
+	Custom               map[string]any       `json:"custom"`
+	ReactionCounts       map[string]int       `json:"reaction_counts"`
+	ReactionScores       map[string]int       `json:"reaction_scores"`
+	User                 UserResponse         `json:"user"`
+	Command              *string              `json:"command,omitempty"`
+	DeletedAt            *Timestamp           `json:"deleted_at,omitempty"`
+	MessageTextUpdatedAt *Timestamp           `json:"message_text_updated_at,omitempty"`
+	Mml                  *string              `json:"mml,omitempty"`
+	ParentID             *string              `json:"parent_id,omitempty"`
+	PinExpires           *Timestamp           `json:"pin_expires,omitempty"`
+	PinnedAt             *Timestamp           `json:"pinned_at,omitempty"`
+	PollID               *string              `json:"poll_id,omitempty"`
+	QuotedMessageID      *string              `json:"quoted_message_id,omitempty"`
+	ShowInChannel        *bool                `json:"show_in_channel,omitempty"`
+	I18n                 map[string]string    `json:"i18n,omitempty"`
+	ImageLabels          map[string][]string  `json:"image_labels,omitempty"`
+	PinnedBy             *UserResponse        `json:"pinned_by,omitempty"`
+	QuotedMessage        *ChatMessageResponse `json:"quoted_message,omitempty"`
+}
+
 type ChatPreferences struct {
 	ChannelMentions         *string `json:"channel_mentions,omitempty"`
 	DefaultPreference       *string `json:"default_preference,omitempty"`
@@ -3697,7 +3762,9 @@ type ConfigResponse struct {
 	SupportedVideoCallHarmTypes []string  `json:"supported_video_call_harm_types"`
 	// Configurable image moderation label definitions for dashboard rendering
 	AiImageLabelDefinitions []AIImageLabelDefinition `json:"ai_image_label_definitions,omitempty"`
-	AiImageConfig           *AIImageConfig           `json:"ai_image_config,omitempty"`
+	// Names of Bodyguard credential profiles registered on this app. The dashboard uses this list to render the profile picker on the AI Text section.
+	AvailableBodyguardProfiles []BodyguardProfileSummary `json:"available_bodyguard_profiles,omitempty"`
+	AiImageConfig              *AIImageConfig            `json:"ai_image_config,omitempty"`
 	// Available L2 subclassifications per L1 image moderation label, based on the active provider
 	AiImageSubclassifications          map[string][]string                 `json:"ai_image_subclassifications,omitempty"`
 	AiTextConfig                       *AITextConfig                       `json:"ai_text_config,omitempty"`
@@ -3751,6 +3818,14 @@ type CreateCallTypeResponse struct {
 	Settings             CallSettingsResponse         `json:"settings"`
 	// the external storage for the call type
 	ExternalStorage *string `json:"external_storage,omitempty"`
+}
+
+// Basic response information
+type CreateCampaignResponse struct {
+	// Duration of the request in milliseconds
+	Duration string            `json:"duration"`
+	Campaign *CampaignResponse `json:"campaign,omitempty"`
+	Users    *PagerResponse    `json:"users,omitempty"`
 }
 
 type CreateChannelTypeResponse struct {
@@ -4032,6 +4107,12 @@ type DecayFunctionConfig struct {
 	Scale *string `json:"scale,omitempty"`
 }
 
+type DeleteActionConfigResponse struct {
+	// Number of action configs deleted (0 or 1)
+	Deleted  int    `json:"deleted"`
+	Duration string `json:"duration"`
+}
+
 type DeleteActivitiesResponse struct {
 	Duration string `json:"duration"`
 	// List of activity IDs that were successfully deleted
@@ -4074,6 +4155,12 @@ type DeleteCallResponse struct {
 	Duration string       `json:"duration"`
 	Call     CallResponse `json:"call"`
 	TaskID   *string      `json:"task_id,omitempty"`
+}
+
+// Basic response information
+type DeleteCampaignResponse struct {
+	// Duration of the request in milliseconds
+	Duration string `json:"duration"`
 }
 
 // Basic response information
@@ -4599,6 +4686,7 @@ type EventHook struct {
 	WebhookUrl                         *string                        `json:"webhook_url,omitempty"`
 	EventTypes                         []string                       `json:"event_types,omitempty"`
 	Callback                           *AsyncModerationCallbackConfig `json:"callback,omitempty"`
+	FailoverConfig                     *WebhookFailoverConfig         `json:"failover_config,omitempty"`
 }
 
 type EventNotificationSettings struct {
@@ -5519,6 +5607,12 @@ type GeofenceSettingsResponse struct {
 	Names []string `json:"names"`
 }
 
+type GetActionConfigResponse struct {
+	Duration string `json:"duration"`
+	// Moderation action configs grouped by entity type, sorted by order ascending
+	ActionConfig map[string][]ModerationActionConfigResponse `json:"action_config"`
+}
+
 // Response containing active calls status information
 type GetActiveCallsStatusResponse struct {
 	Duration string `json:"duration"`
@@ -6000,6 +6094,20 @@ type GoLiveResponse struct {
 
 type GoogleVisionConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type GroupedChannelsBucket struct {
+	// Channels returned for this bucket
+	Channels []ChannelStateResponseFields `json:"channels"`
+	// Unread channels currently classified into this bucket
+	UnreadChannels *int `json:"unread_channels,omitempty"`
+}
+
+type GroupedQueryChannelsResponse struct {
+	// Duration of the request in milliseconds
+	Duration string `json:"duration"`
+	// Predefined channel groups keyed by group name
+	Groups map[string]GroupedChannelsBucket `json:"groups"`
 }
 
 type GroupedStatsResponse struct {
@@ -7013,10 +7121,11 @@ type MessageNewEvent struct {
 	// The number of unread messages
 	UnreadCount *int `json:"unread_count,omitempty"`
 	// The participants of the thread
-	ThreadParticipants []UserResponseCommonFields `json:"thread_participants,omitempty"`
-	Channel            *ChannelResponse           `json:"channel,omitempty"`
-	ChannelCustom      map[string]any             `json:"channel_custom,omitempty"`
-	User               *UserResponseCommonFields  `json:"user,omitempty"`
+	ThreadParticipants    []UserResponseCommonFields `json:"thread_participants,omitempty"`
+	Channel               *ChannelResponse           `json:"channel,omitempty"`
+	ChannelCustom         map[string]any             `json:"channel_custom,omitempty"`
+	GroupedUnreadChannels map[string]int             `json:"grouped_unread_channels,omitempty"`
+	User                  *UserResponseCommonFields  `json:"user,omitempty"`
 }
 
 func (e *MessageNewEvent) GetEventType() string {
@@ -7424,7 +7533,8 @@ type ModerationActionConfigResponse struct {
 	// Icon for the dashboard
 	Icon string `json:"icon"`
 	// Display order (lower numbers shown first)
-	Order int `json:"order"`
+	Order int     `json:"order"`
+	ID    *string `json:"id,omitempty"`
 	// Queue type this action config belongs to
 	QueueType *string `json:"queue_type,omitempty"`
 	// Custom data for the action
@@ -7765,10 +7875,11 @@ type NotificationMarkUnreadEvent struct {
 	// The total number of unread messages in the threads
 	UnreadThreadMessages *int `json:"unread_thread_messages,omitempty"`
 	// The number of unread threads
-	UnreadThreads *int                      `json:"unread_threads,omitempty"`
-	Channel       *ChannelResponse          `json:"channel,omitempty"`
-	ChannelCustom map[string]any            `json:"channel_custom,omitempty"`
-	User          *UserResponseCommonFields `json:"user,omitempty"`
+	UnreadThreads         *int                      `json:"unread_threads,omitempty"`
+	Channel               *ChannelResponse          `json:"channel,omitempty"`
+	ChannelCustom         map[string]any            `json:"channel_custom,omitempty"`
+	GroupedUnreadChannels map[string]int            `json:"grouped_unread_channels,omitempty"`
+	User                  *UserResponseCommonFields `json:"user,omitempty"`
 }
 
 func (e *NotificationMarkUnreadEvent) GetEventType() string {
@@ -9004,10 +9115,20 @@ type QueryReviewQueueResponse struct {
 	// Configuration for moderation actions
 	ActionConfig map[string][]ModerationActionConfigResponse `json:"action_config"`
 	// Statistics about the review queue
-	Stats        map[string]any        `json:"stats"`
-	Next         *string               `json:"next,omitempty"`
-	Prev         *string               `json:"prev,omitempty"`
-	FilterConfig *FilterConfigResponse `json:"filter_config,omitempty"`
+	Stats               map[string]any                              `json:"stats"`
+	Next                *string                                     `json:"next,omitempty"`
+	Prev                *string                                     `json:"prev,omitempty"`
+	DefaultActionConfig map[string][]ModerationActionConfigResponse `json:"default_action_config,omitempty"`
+	FilterConfig        *FilterConfigResponse                       `json:"filter_config,omitempty"`
+}
+
+type QueryRevisionHistoryResponse struct {
+	// Duration of the request in milliseconds
+	Duration string `json:"duration"`
+	// Revision history entries
+	Revisions []RevisionHistoryResponse `json:"revisions"`
+	Next      *string                   `json:"next,omitempty"`
+	Prev      *string                   `json:"prev,omitempty"`
 }
 
 type QuerySegmentTargetsResponse struct {
@@ -9678,7 +9799,7 @@ type ReviewQueueItemResponse struct {
 	FeedsV2Reaction    *Reaction                  `json:"feeds_v2_reaction,omitempty"`
 	FeedsV3Activity    *FeedsV3ActivityResponse   `json:"feeds_v3_activity,omitempty"`
 	FeedsV3Comment     *FeedsV3CommentResponse    `json:"feeds_v3_comment,omitempty"`
-	Message            *MessageResponse           `json:"message,omitempty"`
+	Message            *ChatMessageResponse       `json:"message,omitempty"`
 	ModerationPayload  *ModerationPayloadResponse `json:"moderation_payload,omitempty"`
 	Reaction           *Reaction                  `json:"reaction,omitempty"`
 }
@@ -9697,6 +9818,17 @@ type ReviewQueueItemUpdatedEvent struct {
 
 func (e *ReviewQueueItemUpdatedEvent) GetEventType() string {
 	return e.Type
+}
+
+type RevisionHistoryResponse struct {
+	ActionType            string         `json:"action_type"`
+	ActorType             string         `json:"actor_type"`
+	CreatedAt             Timestamp      `json:"created_at"`
+	ObjectID              string         `json:"object_id"`
+	ObjectType            string         `json:"object_type"`
+	UserID                string         `json:"user_id"`
+	ChangedFields         []string       `json:"changed_fields,omitempty"`
+	PreviousObjSerialized map[string]any `json:"previous_obj_serialized,omitempty"`
 }
 
 type RingCallResponse struct {
@@ -11269,6 +11401,22 @@ type UploadChannelResponse struct {
 	UploadSizes []ImageSize `json:"upload_sizes,omitempty"`
 }
 
+type UpsertActionConfigItem struct {
+	Action      string         `json:"action"`
+	EntityType  string         `json:"entity_type"`
+	Order       int            `json:"order"`
+	Description *string        `json:"description,omitempty"`
+	ID          *string        `json:"id,omitempty"`
+	Icon        *string        `json:"icon,omitempty"`
+	QueueType   *string        `json:"queue_type,omitempty"`
+	Custom      map[string]any `json:"custom,omitempty"`
+}
+
+type UpsertActionConfigResponse struct {
+	Duration     string                          `json:"duration"`
+	ActionConfig *ModerationActionConfigResponse `json:"action_config,omitempty"`
+}
+
 type UpsertActivitiesResponse struct {
 	Duration string `json:"duration"`
 	// List of created or updated activities
@@ -12032,6 +12180,13 @@ type WSEvent struct {
 	Reaction             *ReactionResponse      `json:"reaction,omitempty"`
 	Thread               *ThreadResponse        `json:"thread,omitempty"`
 	User                 *UserResponse          `json:"user,omitempty"`
+}
+
+type WebhookFailoverConfig struct {
+	GcsBucket      *string `json:"gcs_bucket,omitempty"`
+	GcsCredentials *string `json:"gcs_credentials,omitempty"`
+	GcsPath        *string `json:"gcs_path,omitempty"`
+	Type           *string `json:"type,omitempty"`
 }
 
 // Basic response information

--- a/moderation.go
+++ b/moderation.go
@@ -15,6 +15,46 @@ func NewModerationClient(client *Client) *ModerationClient {
 	}
 }
 
+// Returns moderation action configs grouped by entity type, sorted by order ascending. Supports fetching DB-configured actions, hardcoded defaults, or both.
+func (c *ModerationClient) GetActionConfig(ctx context.Context, request *GetActionConfigRequest) (*StreamResponse[GetActionConfigResponse], error) {
+	var result GetActionConfigResponse
+	params := extractQueryParams(request)
+	res, err := MakeRequest[any, GetActionConfigResponse](c.client, ctx, "GET", "/api/v2/moderation/action_config", params, nil, &result, nil)
+	return res, err
+}
+
+// Create a new moderation action config entry or update an existing one. Action configs control the action buttons displayed in the moderation dashboard for each entity type.
+func (c *ModerationClient) UpsertActionConfig(ctx context.Context, request *UpsertActionConfigRequest) (*StreamResponse[UpsertActionConfigResponse], error) {
+	var result UpsertActionConfigResponse
+	res, err := MakeRequest[UpsertActionConfigRequest, UpsertActionConfigResponse](c.client, ctx, "POST", "/api/v2/moderation/action_config", nil, request, &result, nil)
+	return res, err
+}
+
+// Create or update multiple moderation action config entries in a single request. Omit the ID field to create; provide an ID to update.
+func (c *ModerationClient) BulkUpsertActionConfig(ctx context.Context, request *BulkUpsertActionConfigRequest) (*StreamResponse[BulkUpsertActionConfigResponse], error) {
+	var result BulkUpsertActionConfigResponse
+	res, err := MakeRequest[BulkUpsertActionConfigRequest, BulkUpsertActionConfigResponse](c.client, ctx, "POST", "/api/v2/moderation/action_config/bulk", nil, request, &result, nil)
+	return res, err
+}
+
+// Delete multiple moderation action config entries by UUID in a single request.
+func (c *ModerationClient) BulkDeleteActionConfig(ctx context.Context, request *BulkDeleteActionConfigRequest) (*StreamResponse[BulkDeleteActionConfigResponse], error) {
+	var result BulkDeleteActionConfigResponse
+	res, err := MakeRequest[BulkDeleteActionConfigRequest, BulkDeleteActionConfigResponse](c.client, ctx, "POST", "/api/v2/moderation/action_config/bulk_delete", nil, request, &result, nil)
+	return res, err
+}
+
+// Delete a specific moderation action config entry by its UUID.
+func (c *ModerationClient) DeleteActionConfig(ctx context.Context, id string, request *DeleteActionConfigRequest) (*StreamResponse[DeleteActionConfigResponse], error) {
+	var result DeleteActionConfigResponse
+	pathParams := map[string]string{
+		"id": id,
+	}
+	params := extractQueryParams(request)
+	res, err := MakeRequest[any, DeleteActionConfigResponse](c.client, ctx, "DELETE", "/api/v2/moderation/action_config/{id}", params, nil, &result, pathParams)
+	return res, err
+}
+
 // Insert a moderation action log entry. Server-side only. Used by product services to log moderation-related actions.
 func (c *ModerationClient) InsertActionLog(ctx context.Context, request *InsertActionLogRequest) (*StreamResponse[InsertActionLogResponse], error) {
 	var result InsertActionLogResponse

--- a/requests.go
+++ b/requests.go
@@ -82,6 +82,33 @@ type UpdateBlockListRequest struct {
 	// List of words to block
 	Words []string `json:"words"`
 }
+type CreateCampaignRequest struct {
+	// The user ID of the sender
+	SenderID        string                  `json:"sender_id"`
+	MessageTemplate CampaignMessageTemplate `json:"message_template"`
+	// Whether to create channels for the campaign, if they don't exist
+	CreateChannels *bool `json:"create_channels,omitempty"`
+	// The description of the campaign
+	Description *string `json:"description,omitempty"`
+	ID          *string `json:"id,omitempty"`
+	// The name of the campaign
+	Name *string `json:"name,omitempty"`
+	// The sender mode of the campaign
+	SenderMode *string `json:"sender_mode,omitempty"`
+	// The visibility of the created channels for the sender
+	SenderVisibility *string `json:"sender_visibility,omitempty"`
+	// Whether the campaign should show channels, if they are hidden
+	ShowChannels *bool `json:"show_channels,omitempty"`
+	// Whether to skip push notifications
+	SkipPush *bool `json:"skip_push,omitempty"`
+	// Whether to skip webhooks
+	SkipWebhook *bool `json:"skip_webhook,omitempty"`
+	// The IDs of the segments to send the campaign to. Duplicate user IDs are removed. Use either user_ids or segment_ids, not both
+	SegmentIds []string `json:"segment_ids"`
+	// The userIDs to send the campaign to. Use either segment ids or user ids not both
+	UserIds         []string                 `json:"user_ids"`
+	ChannelTemplate *CampaignChannelTemplate `json:"channel_template,omitempty"`
+}
 type QueryCampaignsRequest struct {
 	Limit     *int               `json:"limit,omitempty"`
 	Next      *string            `json:"next,omitempty"`
@@ -90,10 +117,28 @@ type QueryCampaignsRequest struct {
 	Sort      []SortParamRequest `json:"sort"`
 	Filter    map[string]any     `json:"filter"`
 }
+type DeleteCampaignRequest struct {
+}
 type GetCampaignRequest struct {
 	Prev  *string `json:"-" query:"prev"`
 	Next  *string `json:"-" query:"next"`
 	Limit *int    `json:"-" query:"limit"`
+}
+type UpdateCampaignRequest struct {
+	SenderID         string                   `json:"sender_id"`
+	MessageTemplate  CampaignMessageTemplate  `json:"message_template"`
+	CreateChannels   *bool                    `json:"create_channels,omitempty"`
+	Description      *string                  `json:"description,omitempty"`
+	ID               *string                  `json:"id,omitempty"`
+	Name             *string                  `json:"name,omitempty"`
+	SenderMode       *string                  `json:"sender_mode,omitempty"`
+	SenderVisibility *string                  `json:"sender_visibility,omitempty"`
+	ShowChannels     *bool                    `json:"show_channels,omitempty"`
+	SkipPush         *bool                    `json:"skip_push,omitempty"`
+	SkipWebhook      *bool                    `json:"skip_webhook,omitempty"`
+	SegmentIds       []string                 `json:"segment_ids"`
+	UserIds          []string                 `json:"user_ids"`
+	ChannelTemplate  *CampaignChannelTemplate `json:"channel_template,omitempty"`
 }
 type StartCampaignRequest struct {
 	ScheduledFor *Timestamp `json:"scheduled_for,omitempty"`
@@ -139,6 +184,12 @@ type DeleteChannelsRequest struct {
 type MarkDeliveredRequest struct {
 	UserID                  *string                   `json:"-" query:"user_id"`
 	LatestDeliveredMessages []DeliveredMessagePayload `json:"latest_delivered_messages"`
+}
+type GroupedQueryChannelsRequest struct {
+	// Max channels per bucket (default 10)
+	Limit  *int         `json:"limit,omitempty"`
+	UserID *string      `json:"user_id,omitempty"`
+	User   *UserRequest `json:"user,omitempty"`
 }
 type MarkChannelsReadRequest struct {
 	UserID *string `json:"user_id,omitempty"`
@@ -1354,6 +1405,12 @@ type PinActivityRequest struct {
 	UserID          *string      `json:"user_id,omitempty"`
 	User            *UserRequest `json:"user,omitempty"`
 }
+type ChangeFeedVisibilityRequest struct {
+	// Feed visibility level: public, visible, followers, members, or private
+	Visibility string `json:"visibility"`
+	// What to do with existing pending follows when loosening visibility from 'followers': auto_approve (default) or reject
+	PendingFollowsAction *string `json:"pending_follows_action,omitempty"`
+}
 type UpdateFeedMembersRequest struct {
 	// Type of update operation to perform. One of: upsert, remove, set
 	Operation string  `json:"operation"`
@@ -1638,6 +1695,15 @@ type UpdateMembershipLevelRequest struct {
 	// Custom data for the membership level
 	Custom map[string]any `json:"custom"`
 }
+type QueryRevisionHistoryRequest struct {
+	// Filter to apply to the query
+	Filter map[string]any `json:"filter"`
+	Limit  *int           `json:"limit,omitempty"`
+	Next   *string        `json:"next,omitempty"`
+	Prev   *string        `json:"prev,omitempty"`
+	// Array of sort parameters
+	Sort []SortParamRequest `json:"sort"`
+}
 type QueryFeedsUsageStatsRequest struct {
 	// Start date in YYYY-MM-DD format (optional, defaults to 30 days ago)
 	From *string `json:"from,omitempty"`
@@ -1704,6 +1770,49 @@ type GetImportV2TaskRequest struct {
 }
 type GetImportRequest struct {
 }
+type GetActionConfigRequest struct {
+	QueueType       *string `json:"-" query:"queue_type"`
+	EntityType      *string `json:"-" query:"entity_type"`
+	ExcludeDefaults *bool   `json:"-" query:"exclude_defaults"`
+	OnlyDefaults    *bool   `json:"-" query:"only_defaults"`
+	UserID          *string `json:"-" query:"user_id"`
+}
+type UpsertActionConfigRequest struct {
+	// The action to perform (e.g. ban, delete_message, custom)
+	Action string `json:"action"`
+	// Type of entity this action applies to (e.g. stream:chat:v1:message)
+	EntityType string `json:"entity_type"`
+	// Display order in the dashboard (0–100, lower numbers shown first)
+	Order int `json:"order"`
+	// Human-readable label for the dashboard button
+	Description *string `json:"description,omitempty"`
+	// UUID of an existing action config to update; omit to create a new record
+	ID *string `json:"id,omitempty"`
+	// Icon identifier for the dashboard button
+	Icon *string `json:"icon,omitempty"`
+	// Queue this config belongs to; null means the default queue
+	QueueType *string `json:"queue_type,omitempty"`
+	// Optional user ID to associate with the audit log entry
+	UserID *string `json:"user_id,omitempty"`
+	// Action-specific parameters passed to the action handler
+	Custom map[string]any `json:"custom"`
+	User   *UserRequest   `json:"user,omitempty"`
+}
+type BulkUpsertActionConfigRequest struct {
+	// List of action configs to create or update
+	ActionConfigs []UpsertActionConfigItem `json:"action_configs"`
+	UserID        *string                  `json:"user_id,omitempty"`
+	User          *UserRequest             `json:"user,omitempty"`
+}
+type BulkDeleteActionConfigRequest struct {
+	// UUIDs of the action configs to delete
+	Ids    []string     `json:"ids"`
+	UserID *string      `json:"user_id,omitempty"`
+	User   *UserRequest `json:"user,omitempty"`
+}
+type DeleteActionConfigRequest struct {
+	UserID *string `json:"-" query:"user_id"`
+}
 type InsertActionLogRequest struct {
 	// Type of moderation action taken
 	ActionType string `json:"action_type"`
@@ -1715,6 +1824,10 @@ type InsertActionLogRequest struct {
 	EntityType string `json:"entity_type"`
 	// Reason for the action
 	Reason *string `json:"reason,omitempty"`
+	// Type of reporter; 'api_integration' when the action was triggered by an API integration call with no authenticated user
+	ReporterType *string `json:"reporter_type,omitempty"`
+	// ID of the user who triggered the action; empty for automated actions
+	ReporterUserID *string `json:"reporter_user_id,omitempty"`
 	// Custom metadata for the action log
 	Custom map[string]any `json:"custom"`
 }
@@ -1979,7 +2092,8 @@ type MuteRequest struct {
 	User    *UserRequest `json:"user,omitempty"`
 }
 type QueryReviewQueueRequest struct {
-	Limit *int `json:"limit,omitempty"`
+	ExcludeDefaultActionConfig *bool `json:"exclude_default_action_config,omitempty"`
+	Limit                      *int  `json:"limit,omitempty"`
 	// Number of items to lock (1-25)
 	LockCount *int `json:"lock_count,omitempty"`
 	// Duration for which items should be locked


### PR DESCRIPTION
## Summary
- Regenerate Go SDK client code from the latest Chat OpenAPI spec.
- Add new generated models/endpoints and update existing request/response structs.
- Keep scope limited to generated Go SDK files only.

## Test plan
- [x] `make openapi` in `chat`
- [x] Regenerate Go SDK client output
- [x] `go build ./...`

Made with [Cursor](https://cursor.com)