### PR TITLE
[CHA-3056] PROBE: capture HardDeleteChannels task error description

### DIFF
--- a/chat_channel_integration_test.go
+++ b/chat_channel_integration_test.go
@@ -185,6 +185,7 @@ func TestChatChannelIntegration(t *testing.T) {
 		// retries; this loop surfaces those transient observations so we
 		// can see the exact backend reason. Revert before merging.
 		taskID := *resp.Data.TaskID
+		t.Logf("CHA-3056 probe: task_id=%s api_key=%s cids=[%s,%s]", taskID, "d2sj6pudbhz7", cid1, cid2)
 		const maxAttempts = 30
 		var taskResult *StreamResponse[GetTaskResponse]
 		failedObservations := 0

--- a/chat_channel_integration_test.go
+++ b/chat_channel_integration_test.go
@@ -178,18 +178,38 @@ func TestChatChannelIntegration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Data.TaskID)
 
-		// PROBE for CHA-3056: temporarily re-assert "completed" so CI fails
-		// loud whenever the bulk hard-delete task surfaces non-terminal-completed.
-		// Logs the task error description before failing so we can read the
-		// exact backend reason from CI output. Revert before merging.
-		taskResult, err := WaitForTask(ctx, client, *resp.Data.TaskID)
-		require.NoError(t, err)
-		if taskResult.Data.Status != "completed" {
-			t.Logf("DeleteChannels task did not complete in window: status=%s", taskResult.Data.Status)
-			if taskResult.Data.Error != nil {
-				t.Logf("DeleteChannels task error: type=%s description=%q", taskResult.Data.Error.Type, taskResult.Data.Error.Description)
+		// PROBE for CHA-3056: inline poll loop that logs every "failed"
+		// observation with the backend's error type/description, then keeps
+		// polling. WaitForTask absorbs intermediate "failed" statuses
+		// silently because the chat backend writes "failed" before asynq
+		// retries; this loop surfaces those transient observations so we
+		// can see the exact backend reason. Revert before merging.
+		taskID := *resp.Data.TaskID
+		const maxAttempts = 30
+		var taskResult *StreamResponse[GetTaskResponse]
+		failedObservations := 0
+		for i := 0; i < maxAttempts; i++ {
+			r, err := client.GetTask(context.Background(), taskID, &GetTaskRequest{})
+			require.NoError(t, err)
+			taskResult = r
+			if r.Data.Status == "failed" {
+				failedObservations++
+				if r.Data.Error != nil {
+					t.Logf("CHA-3056 probe: attempt=%d status=failed type=%s description=%q", i+1, r.Data.Error.Type, r.Data.Error.Description)
+				} else {
+					t.Logf("CHA-3056 probe: attempt=%d status=failed (no error payload)", i+1)
+				}
 			}
+			if r.Data.Status == "completed" {
+				break
+			}
+			interval := time.Duration(i+1) * time.Second
+			if interval > 5*time.Second {
+				interval = 5 * time.Second
+			}
+			time.Sleep(interval)
 		}
+		t.Logf("CHA-3056 probe: terminal_status=%s failed_observations=%d", taskResult.Data.Status, failedObservations)
 		assert.Equal(t, "completed", taskResult.Data.Status, "CHA-3056 probe: see preceding t.Logf for task error description")
 	})
 

--- a/chat_channel_integration_test.go
+++ b/chat_channel_integration_test.go
@@ -188,17 +188,21 @@ func TestChatChannelIntegration(t *testing.T) {
 		const maxAttempts = 30
 		var taskResult *StreamResponse[GetTaskResponse]
 		failedObservations := 0
+		probeStart := time.Now()
 		for i := 0; i < maxAttempts; i++ {
 			r, err := client.GetTask(context.Background(), taskID, &GetTaskRequest{})
 			require.NoError(t, err)
 			taskResult = r
+			elapsed := time.Since(probeStart).Truncate(time.Millisecond)
 			if r.Data.Status == "failed" {
 				failedObservations++
 				if r.Data.Error != nil {
-					t.Logf("CHA-3056 probe: attempt=%d status=failed type=%s description=%q", i+1, r.Data.Error.Type, r.Data.Error.Description)
+					t.Logf("CHA-3056 probe: attempt=%d elapsed=%s status=failed type=%s description=%q", i+1, elapsed, r.Data.Error.Type, r.Data.Error.Description)
 				} else {
-					t.Logf("CHA-3056 probe: attempt=%d status=failed (no error payload)", i+1)
+					t.Logf("CHA-3056 probe: attempt=%d elapsed=%s status=failed (no error payload)", i+1, elapsed)
 				}
+			} else {
+				t.Logf("CHA-3056 probe: attempt=%d elapsed=%s status=%s", i+1, elapsed, r.Data.Status)
 			}
 			if r.Data.Status == "completed" {
 				break
@@ -209,8 +213,8 @@ func TestChatChannelIntegration(t *testing.T) {
 			}
 			time.Sleep(interval)
 		}
-		t.Logf("CHA-3056 probe: terminal_status=%s failed_observations=%d", taskResult.Data.Status, failedObservations)
-		assert.Equal(t, "completed", taskResult.Data.Status, "CHA-3056 probe: see preceding t.Logf for task error description")
+		t.Logf("CHA-3056 probe: terminal_status=%s failed_observations=%d total_elapsed=%s", taskResult.Data.Status, failedObservations, time.Since(probeStart).Truncate(time.Millisecond))
+		assert.Equal(t, "completed", taskResult.Data.Status, "CHA-3056 probe: see preceding t.Logf lines for task lifecycle")
 	})
 
 	t.Run("AddRemoveMembers", func(t *testing.T) {

--- a/chat_channel_integration_test.go
+++ b/chat_channel_integration_test.go
@@ -178,10 +178,10 @@ func TestChatChannelIntegration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Data.TaskID)
 
-		// The bulk-delete task can fail-and-retry repeatedly on the shared CI
-		// app under load; we treat completion as best-effort. The strong
-		// guarantee tested here is that the SDK call succeeds and returns a
-		// task ID — the task lifecycle is a backend concern.
+		// PROBE for CHA-3056: temporarily re-assert "completed" so CI fails
+		// loud whenever the bulk hard-delete task surfaces non-terminal-completed.
+		// Logs the task error description before failing so we can read the
+		// exact backend reason from CI output. Revert before merging.
 		taskResult, err := WaitForTask(ctx, client, *resp.Data.TaskID)
 		require.NoError(t, err)
 		if taskResult.Data.Status != "completed" {
@@ -190,6 +190,7 @@ func TestChatChannelIntegration(t *testing.T) {
 				t.Logf("DeleteChannels task error: type=%s description=%q", taskResult.Data.Error.Type, taskResult.Data.Error.Description)
 			}
 		}
+		assert.Equal(t, "completed", taskResult.Data.Status, "CHA-3056 probe: see preceding t.Logf for task error description")
 	})
 
 	t.Run("AddRemoveMembers", func(t *testing.T) {


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/CHA-3056/harddeletechannels-async-task-failure-in-getstream-go-ci

## Summary
PROBE only, do not merge. Re-asserts that the bulk hard-delete async task reaches `"completed"` status so CI fails loud when the regression hits. Existing `t.Logf` (added in 02db428) already captures the task's terminal status and error description — this commit makes CI red so the log line surfaces in the job output, giving us the exact backend reason for the failure (e.g. `RateLimitError`, FK violation, context deadline, etc.).

## Why
The asynq.go error path that writes `Status="failed"` before retry is 2 years old, so blaming it for the recent regression is unproven. We need the actual `taskResult.Data.Error.Description` from a failing CI run to know whether the trigger is shared-app contention, a backend regression in `state.DeleteChannel`, or something else. Without it, any fix is speculation.

## Test plan
- [ ] Wait for `Test & Build 1.19 & Integration` job to fail
- [ ] Read the `t.Logf` output in the failed-job log to capture the task error type/description
- [ ] Decide remediation based on what the description says

Revert before merging.