### PR TITLE
[CHA-2956] connection pooling: getstream-go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,13 @@ All notable changes to this project will be documented in this file. See [standa
     * `WithIdleTimeout(time.Duration)` - default `55s`
     * `WithConnectTimeout(time.Duration)` - default `10s`
     * `WithRequestTimeout(time.Duration)` - default `30s` (was `6s`; see Behavior changes)
-  These tune the underlying `*http.Transport`. `WithHTTPClient` continues to act as
-  an escape hatch - when set, none of the four new options apply.
+  These tune the underlying `*http.Transport`. `WithHTTPClient` continues to act as an escape hatch - when set, none of the four new options apply.
 * INFO log on client construction lists the effective pool config.
 
 ### Behavior changes
 
-* **Default `RequestTimeout` is now `30s` (was `6s`).** Aligns the Go SDK with the
-  cross-SDK contract in CHA-2956. Existing callers using `WithTimeout(...)` are
-  unaffected. Callers relying on the 6s ceiling for fail-fast behavior should
-  pass `WithRequestTimeout(6 * time.Second)` (or `WithTimeout(...)`, kept as an
-  alias for backward compatibility).
-* Default HTTP transport now caps connections per host at `5` and closes idle
-  sockets after `55s` (vs. unlimited / unbounded previously). Behavior matches
-  legacy `stream-chat-go` (5 / 59s) modulo the 4s tighter idle window.
+* **Default `RequestTimeout` is now `30s` (was `6s`).** Aligns the Go SDK with the cross-SDK contract in CHA-2956. Existing callers using `WithTimeout(...)` are unaffected. Callers relying on the 6s ceiling for fail-fast behavior should pass `WithRequestTimeout(6 * time.Second)` (or `WithTimeout(...)`, kept as an alias for backward compatibility).
+* Default HTTP transport now caps connections per host at `5` and closes idle sockets after `55s` (vs. unlimited / unbounded previously). Behavior matches legacy `stream-chat-go` (5 / 59s) modulo the 4s tighter idle window.
 
 ### [4.1.1](https://github.com/GetStream/getstream-go/compare/v4.1.0...v4.1.1) (2026-05-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,13 @@ All notable changes to this project will be documented in this file. See [standa
 
 * Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
   Four new functional options:
-    * `WithMaxConnsPerHost(int)` — default `5`
-    * `WithIdleTimeout(time.Duration)` — default `55s`
-    * `WithConnectTimeout(time.Duration)` — default `10s`
-    * `WithRequestTimeout(time.Duration)` — default `30s` (was `6s`; see Behavior changes)
+    * `WithMaxConnsPerHost(int)` - default `5`
+    * `WithIdleTimeout(time.Duration)` - default `55s`
+    * `WithConnectTimeout(time.Duration)` - default `10s`
+    * `WithRequestTimeout(time.Duration)` - default `30s` (was `6s`; see Behavior changes)
   These tune the underlying `*http.Transport`. `WithHTTPClient` continues to act as
-  an escape hatch — when set, none of the four new options apply.
-  See the [Connection Pooling Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108).
-* INFO log on client construction lists the effective pool config (spec §8).
+  an escape hatch - when set, none of the four new options apply.
+* INFO log on client construction lists the effective pool config.
 
 ### Behavior changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.2.0](https://github.com/GetStream/getstream-go/compare/v4.1.1...v4.2.0) (2026-MM-DD)
+
+### Features
+
+* Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
+  Four new functional options:
+    * `WithMaxConnsPerHost(int)` — default `5`
+    * `WithIdleTimeout(time.Duration)` — default `55s`
+    * `WithConnectTimeout(time.Duration)` — default `10s`
+    * `WithRequestTimeout(time.Duration)` — default `30s` (was `6s`; see Behavior changes)
+  These tune the underlying `*http.Transport`. `WithHTTPClient` continues to act as
+  an escape hatch — when set, none of the four new options apply.
+  See the [Connection Pooling Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108).
+* INFO log on client construction lists the effective pool config (spec §8).
+
+### Behavior changes
+
+* **Default `RequestTimeout` is now `30s` (was `6s`).** Aligns the Go SDK with the
+  cross-SDK contract in CHA-2956. Existing callers using `WithTimeout(...)` are
+  unaffected. Callers relying on the 6s ceiling for fail-fast behavior should
+  pass `WithRequestTimeout(6 * time.Second)` (or `WithTimeout(...)`, kept as an
+  alias for backward compatibility).
+* Default HTTP transport now caps connections per host at `5` and closes idle
+  sockets after `55s` (vs. unlimited / unbounded previously). Behavior matches
+  legacy `stream-chat-go` (5 / 59s) modulo the 4s tighter idle window.
+
 ### [4.1.1](https://github.com/GetStream/getstream-go/compare/v4.1.0...v4.1.1) (2026-05-21)
 
 ## [4.1.0](https://github.com/GetStream/getstream-go/compare/v4.0.6...v4.1.0) (2026-05-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 * Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
   Four new functional options:
-    * `WithMaxConnsPerHost(int)` - default `5`
-    * `WithIdleTimeout(time.Duration)` - default `55s`
-    * `WithConnectTimeout(time.Duration)` - default `10s`
-    * `WithRequestTimeout(time.Duration)` - default `30s` (was `6s`; see Behavior changes)
-  These tune the underlying `*http.Transport`. `WithHTTPClient` continues to act as an escape hatch - when set, none of the four new options apply.
+    * `WithMaxConnsPerHost(int)`: default `5`
+    * `WithIdleTimeout(time.Duration)`: default `55s`
+    * `WithConnectTimeout(time.Duration)`: default `10s`
+    * `WithRequestTimeout(time.Duration)`: default `30s` (was `6s`; see Behavior changes)
+  These tune the underlying `*http.Transport`. `WithHTTPClient` continues to act as an escape hatch; when set, none of the four new options apply.
 * INFO log on client construction lists the effective pool config.
 
 ### Behavior changes

--- a/client.go
+++ b/client.go
@@ -31,9 +31,6 @@ const (
 	DefaultIdleTimeout = 55 * time.Second
 	// DefaultConnectTimeout caps TCP + TLS handshake duration.
 	DefaultConnectTimeout = 10 * time.Second
-
-	// defaultTimeout is preserved for backwards compatibility of internal references.
-	defaultTimeout = DefaultRequestTimeout
 )
 
 func PtrTo[T any](v T) *T {

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -21,7 +22,18 @@ const (
 	// It works like CDN style and connects you to the closest production server.
 	// By default, there is no real reason to change it. Use it only if you know what you are doing.
 	DefaultBaseURL = "https://chat.stream-io-api.com"
-	defaultTimeout = 6 * time.Second
+
+	// DefaultRequestTimeout is the default per-request timeout (was 6s prior to v4.2.0).
+	DefaultRequestTimeout = 30 * time.Second
+	// DefaultMaxConnsPerHost caps concurrent TCP connections per host.
+	DefaultMaxConnsPerHost = 5
+	// DefaultIdleTimeout sits below the typical 60s LB idle timeout with a 5s safety margin.
+	DefaultIdleTimeout = 55 * time.Second
+	// DefaultConnectTimeout caps TCP + TLS handshake duration.
+	DefaultConnectTimeout = 10 * time.Second
+
+	// defaultTimeout is preserved for backwards compatibility of internal references.
+	defaultTimeout = DefaultRequestTimeout
 )
 
 func PtrTo[T any](v T) *T {
@@ -33,13 +45,17 @@ type HttpClient interface {
 }
 
 type Client struct {
-	apiKey         string
-	apiSecret      []byte
-	authToken      string
-	baseUrl        string
-	defaultTimeout time.Duration
-	httpClient     HttpClient
-	logger         Logger
+	apiKey             string
+	apiSecret          []byte
+	authToken          string
+	baseUrl            string
+	defaultTimeout     time.Duration
+	maxConnsPerHost    int
+	idleTimeout        time.Duration
+	connectTimeout     time.Duration
+	httpClient         HttpClient
+	httpClientFromUser bool // true iff WithHTTPClient was used; gates transport build
+	logger             Logger
 }
 
 func (c *Client) HttpClient() HttpClient {
@@ -67,6 +83,7 @@ type ClientOption func(c *Client)
 func WithHTTPClient(httpClient HttpClient) ClientOption {
 	return func(c *Client) {
 		c.httpClient = httpClient
+		c.httpClientFromUser = true
 	}
 }
 
@@ -74,6 +91,40 @@ func WithHTTPClient(httpClient HttpClient) ClientOption {
 func WithTimeout(t time.Duration) ClientOption {
 	return func(c *Client) {
 		c.defaultTimeout = t
+	}
+}
+
+// WithMaxConnsPerHost caps concurrent TCP connections per host. Default: 5.
+// Ignored when WithHTTPClient is set.
+func WithMaxConnsPerHost(n int) ClientOption {
+	return func(c *Client) {
+		c.maxConnsPerHost = n
+	}
+}
+
+// WithIdleTimeout sets how long an idle connection lingers before being closed.
+// Default: 55s (sits 5s below the typical 60s LB idle timeout). Ignored when
+// WithHTTPClient is set.
+func WithIdleTimeout(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.idleTimeout = d
+	}
+}
+
+// WithConnectTimeout caps TCP+TLS handshake duration. Default: 10s. Ignored
+// when WithHTTPClient is set.
+func WithConnectTimeout(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.connectTimeout = d
+	}
+}
+
+// WithRequestTimeout sets the default per-request timeout. Default: 30s.
+// Callers can still override per-call via context.WithTimeout. Ignored when
+// WithHTTPClient is set.
+func WithRequestTimeout(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.defaultTimeout = d
 	}
 }
 
@@ -136,6 +187,26 @@ func newClientFromEnvVars(options ...ClientOption) (*Client, error) {
 	return newClient(apiKey, apiSecret, options...)
 }
 
+// buildDefaultHTTPClient constructs the SDK's default *http.Client with the
+// spec-mandated transport tuning. It clones http.DefaultTransport so any
+// runtime-provided ProxyFromEnvironment, ALPN, etc. defaults are preserved.
+func buildDefaultHTTPClient(requestTimeout time.Duration, maxConnsPerHost int, idleTimeout, connectTimeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxConnsPerHost = maxConnsPerHost
+	transport.MaxIdleConnsPerHost = maxConnsPerHost
+	transport.IdleConnTimeout = idleTimeout
+	transport.DialContext = (&net.Dialer{
+		Timeout:   connectTimeout,
+		KeepAlive: 30 * time.Second, // OS-level TCP keep-alive; unrelated to HTTP keep-alive
+	}).DialContext
+	transport.DisableKeepAlives = false // §5 invariant 4
+
+	return &http.Client{
+		Timeout:   requestTimeout,
+		Transport: transport,
+	}
+}
+
 func newClient(apiKey, apiSecret string, options ...ClientOption) (*Client, error) {
 	if apiKey == "" {
 		return nil, errors.New("API key is empty")
@@ -151,10 +222,13 @@ func newClient(apiKey, apiSecret string, options ...ClientOption) (*Client, erro
 	}
 
 	client := &Client{
-		apiKey:         apiKey,
-		apiSecret:      []byte(apiSecret),
-		baseUrl:        baseURL,
-		defaultTimeout: defaultTimeout,
+		apiKey:          apiKey,
+		apiSecret:       []byte(apiSecret),
+		baseUrl:         baseURL,
+		defaultTimeout:  DefaultRequestTimeout,
+		maxConnsPerHost: DefaultMaxConnsPerHost,
+		idleTimeout:     DefaultIdleTimeout,
+		connectTimeout:  DefaultConnectTimeout,
 	}
 
 	if timeoutEnv := os.Getenv(EnvStreamHttpTimeout); timeoutEnv != "" {
@@ -175,9 +249,12 @@ func newClient(apiKey, apiSecret string, options ...ClientOption) (*Client, erro
 	}
 
 	if client.httpClient == nil {
-		client.httpClient = &http.Client{
-			Timeout: client.defaultTimeout,
-		}
+		client.httpClient = buildDefaultHTTPClient(
+			client.defaultTimeout,
+			client.maxConnsPerHost,
+			client.idleTimeout,
+			client.connectTimeout,
+		)
 	}
 
 	if client.authToken == "" {

--- a/client.go
+++ b/client.go
@@ -23,14 +23,14 @@ const (
 	// By default, there is no real reason to change it. Use it only if you know what you are doing.
 	DefaultBaseURL = "https://chat.stream-io-api.com"
 
-	// DefaultRequestTimeout is the default per-request timeout (was 6s prior to v4.2.0).
-	DefaultRequestTimeout = 30 * time.Second
-	// DefaultMaxConnsPerHost caps concurrent TCP connections per host.
-	DefaultMaxConnsPerHost = 5
-	// DefaultIdleTimeout sits below the typical 60s LB idle timeout with a 5s safety margin.
-	DefaultIdleTimeout = 55 * time.Second
-	// DefaultConnectTimeout caps TCP + TLS handshake duration.
-	DefaultConnectTimeout = 10 * time.Second
+	// defaultRequestTimeout is the default per-request timeout (was 6s prior to v4.2.0).
+	defaultRequestTimeout = 30 * time.Second
+	// defaultMaxConnsPerHost caps concurrent TCP connections per host.
+	defaultMaxConnsPerHost = 5
+	// defaultIdleTimeout sits below the typical 60s LB idle timeout with a 5s safety margin.
+	defaultIdleTimeout = 55 * time.Second
+	// defaultConnectTimeout caps TCP + TLS handshake duration.
+	defaultConnectTimeout = 10 * time.Second
 )
 
 func PtrTo[T any](v T) *T {
@@ -230,10 +230,10 @@ func newClient(apiKey, apiSecret string, options ...ClientOption) (*Client, erro
 		apiKey:          apiKey,
 		apiSecret:       []byte(apiSecret),
 		baseUrl:         baseURL,
-		defaultTimeout:  DefaultRequestTimeout,
-		maxConnsPerHost: DefaultMaxConnsPerHost,
-		idleTimeout:     DefaultIdleTimeout,
-		connectTimeout:  DefaultConnectTimeout,
+		defaultTimeout:  defaultRequestTimeout,
+		maxConnsPerHost: defaultMaxConnsPerHost,
+		idleTimeout:     defaultIdleTimeout,
+		connectTimeout:  defaultConnectTimeout,
 	}
 
 	if timeoutEnv := os.Getenv(EnvStreamHttpTimeout); timeoutEnv != "" {

--- a/client.go
+++ b/client.go
@@ -75,6 +75,18 @@ func (c *Client) DefaultTimeout() time.Duration {
 	return c.defaultTimeout
 }
 
+func (c *Client) MaxConnsPerHost() int {
+	return c.maxConnsPerHost
+}
+
+func (c *Client) IdleTimeout() time.Duration {
+	return c.idleTimeout
+}
+
+func (c *Client) ConnectTimeout() time.Duration {
+	return c.connectTimeout
+}
+
 type ClientOption func(c *Client)
 
 func WithHTTPClient(httpClient HttpClient) ClientOption {

--- a/client.go
+++ b/client.go
@@ -264,6 +264,19 @@ func newClient(apiKey, apiSecret string, options ...ClientOption) (*Client, erro
 		}
 		client.authToken = token
 	}
+
+	if client.httpClientFromUser {
+		client.logger.Info("connection pool: user_http_client=true (5 knobs not applied)")
+	} else {
+		client.logger.Info(
+			"connection pool: max_conns_per_host=%d idle_timeout=%s connect_timeout=%s request_timeout=%s user_http_client=false",
+			client.maxConnsPerHost,
+			client.idleTimeout,
+			client.connectTimeout,
+			client.defaultTimeout,
+		)
+	}
+
 	return client, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -196,7 +196,7 @@ func buildDefaultHTTPClient(requestTimeout time.Duration, maxConnsPerHost int, i
 		Timeout:   connectTimeout,
 		KeepAlive: 30 * time.Second, // OS-level TCP keep-alive; unrelated to HTTP keep-alive
 	}).DialContext
-	transport.DisableKeepAlives = false // §5 invariant 4
+	transport.DisableKeepAlives = false // keep-alive stays on; never emit Connection: close
 
 	return &http.Client{
 		Timeout:   requestTimeout,

--- a/client.go
+++ b/client.go
@@ -100,16 +100,14 @@ func WithMaxConnsPerHost(n int) ClientOption {
 }
 
 // WithIdleTimeout sets how long an idle connection lingers before being closed.
-// Default: 55s (sits 5s below the typical 60s LB idle timeout). Ignored when
-// WithHTTPClient is set.
+// Default: 55s (sits 5s below the typical 60s LB idle timeout). Ignored when WithHTTPClient is set.
 func WithIdleTimeout(d time.Duration) ClientOption {
 	return func(c *Client) {
 		c.idleTimeout = d
 	}
 }
 
-// WithConnectTimeout caps TCP+TLS handshake duration. Default: 10s. Ignored
-// when WithHTTPClient is set.
+// WithConnectTimeout caps TCP+TLS handshake duration. Default: 10s. Ignored when WithHTTPClient is set.
 func WithConnectTimeout(d time.Duration) ClientOption {
 	return func(c *Client) {
 		c.connectTimeout = d
@@ -117,8 +115,7 @@ func WithConnectTimeout(d time.Duration) ClientOption {
 }
 
 // WithRequestTimeout sets the default per-request timeout. Default: 30s.
-// Callers can still override per-call via context.WithTimeout. Ignored when
-// WithHTTPClient is set.
+// Callers can still override per-call via context.WithTimeout. Ignored when WithHTTPClient is set.
 func WithRequestTimeout(d time.Duration) ClientOption {
 	return func(c *Client) {
 		c.defaultTimeout = d
@@ -184,9 +181,8 @@ func newClientFromEnvVars(options ...ClientOption) (*Client, error) {
 	return newClient(apiKey, apiSecret, options...)
 }
 
-// buildDefaultHTTPClient constructs the SDK's default *http.Client with the
-// spec-mandated transport tuning. It clones http.DefaultTransport so any
-// runtime-provided ProxyFromEnvironment, ALPN, etc. defaults are preserved.
+// buildDefaultHTTPClient constructs the SDK's default *http.Client with the spec-mandated transport tuning.
+// It clones http.DefaultTransport so any runtime-provided ProxyFromEnvironment, ALPN, etc. defaults are preserved.
 func buildDefaultHTTPClient(requestTimeout time.Duration, maxConnsPerHost int, idleTimeout, connectTimeout time.Duration) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxConnsPerHost = maxConnsPerHost

--- a/client_test.go
+++ b/client_test.go
@@ -236,6 +236,43 @@ func TestClientHTTPClientEscapeHatch(t *testing.T) {
 	assert.Nil(t, got.Transport, "SDK MUST NOT install a Transport on a user-supplied client")
 }
 
+type captureLogger struct {
+	infos []string
+}
+
+func (l *captureLogger) Debug(format string, v ...interface{}) {}
+func (l *captureLogger) Info(format string, v ...interface{}) {
+	l.infos = append(l.infos, fmt.Sprintf(format, v...))
+}
+func (l *captureLogger) Warn(format string, v ...interface{})  {}
+func (l *captureLogger) Error(format string, v ...interface{}) {}
+
+func TestClientInfoLogOnConstruction(t *testing.T) {
+	cap := &captureLogger{}
+	_, err := NewClient("apiKey", "apiSecret", WithLogger(cap))
+	require.NoError(t, err)
+
+	require.Len(t, cap.infos, 1, "exactly one INFO line on construction")
+	got := cap.infos[0]
+	assert.Contains(t, got, "max_conns_per_host=5")
+	assert.Contains(t, got, "idle_timeout=55s")
+	assert.Contains(t, got, "connect_timeout=10s")
+	assert.Contains(t, got, "request_timeout=30s")
+	assert.Contains(t, got, "user_http_client=false")
+}
+
+func TestClientInfoLogWithUserHTTPClient(t *testing.T) {
+	cap := &captureLogger{}
+	_, err := NewClient("apiKey", "apiSecret",
+		WithLogger(cap),
+		WithHTTPClient(&http.Client{Timeout: time.Second}),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, cap.infos, 1)
+	assert.Contains(t, cap.infos[0], "user_http_client=true")
+}
+
 func TestClientGetters(t *testing.T) {
 	customLogger := NewDefaultLogger(os.Stderr, "", log.LstdFlags, LogLevelInfo)
 	client, err := NewClient("apiKey", "apiSecret", WithLogger(customLogger))

--- a/client_test.go
+++ b/client_test.go
@@ -191,11 +191,15 @@ func resetCallResource(t *testing.T, call *Call) {
 func TestClientTimeout(t *testing.T) {
 	client, err := NewClient("apiKey", "apiSecret")
 	require.NoError(t, err)
-	assert.Equal(t, 6*time.Second, client.HttpClient().(*http.Client).Timeout)
+	assert.Equal(t, 30*time.Second, client.HttpClient().(*http.Client).Timeout)
 
 	client, err = NewClient("apiKey", "apiSecret", WithTimeout(time.Second))
 	require.NoError(t, err)
 	assert.Equal(t, time.Second, client.HttpClient().(*http.Client).Timeout)
+
+	client, err = NewClient("apiKey", "apiSecret", WithRequestTimeout(5*time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, client.HttpClient().(*http.Client).Timeout)
 }
 
 func TestClientDefaultTransportConfig(t *testing.T) {
@@ -225,7 +229,7 @@ func TestClientGetters(t *testing.T) {
 
 	assert.Equal(t, "apiKey", client.ApiKey())
 	assert.Equal(t, "https://chat.stream-io-api.com", client.BaseUrl())
-	assert.Equal(t, 6*time.Second, client.DefaultTimeout())
+	assert.Equal(t, 30*time.Second, client.DefaultTimeout())
 }
 
 // TestCRUDCallTypeOperations tests Create, Read, Update, and Delete operations for call types.

--- a/client_test.go
+++ b/client_test.go
@@ -297,7 +297,8 @@ func TestClientPerCallTimeoutOverride(t *testing.T) {
 	}))
 	defer slowServer.Close()
 
-	client, err := NewClient("apiKey", "apiSecret",
+	client, err := NewClient(
+		"apiKey", "apiSecret",
 		WithBaseUrl(slowServer.URL),
 		WithRequestTimeout(30*time.Second),
 	)

--- a/client_test.go
+++ b/client_test.go
@@ -198,6 +198,21 @@ func TestClientTimeout(t *testing.T) {
 	assert.Equal(t, time.Second, client.HttpClient().(*http.Client).Timeout)
 }
 
+func TestClientDefaultTransportConfig(t *testing.T) {
+	client, err := NewClient("apiKey", "apiSecret")
+	require.NoError(t, err)
+
+	httpClient := client.HttpClient().(*http.Client)
+	assert.Equal(t, 30*time.Second, httpClient.Timeout, "default RequestTimeout = 30s")
+
+	tr, ok := httpClient.Transport.(*http.Transport)
+	require.True(t, ok, "default transport must be *http.Transport, not nil")
+	assert.Equal(t, 5, tr.MaxConnsPerHost, "default MaxConnsPerHost = 5")
+	assert.Equal(t, 5, tr.MaxIdleConnsPerHost, "default MaxIdleConnsPerHost = 5")
+	assert.Equal(t, 55*time.Second, tr.IdleConnTimeout, "default IdleTimeout = 55s")
+	assert.False(t, tr.DisableKeepAlives, "KeepAlive invariant")
+}
+
 func TestClientGetters(t *testing.T) {
 	customLogger := NewDefaultLogger(os.Stderr, "", log.LstdFlags, LogLevelInfo)
 	client, err := NewClient("apiKey", "apiSecret", WithLogger(customLogger))

--- a/client_test.go
+++ b/client_test.go
@@ -217,6 +217,25 @@ func TestClientDefaultTransportConfig(t *testing.T) {
 	assert.False(t, tr.DisableKeepAlives, "KeepAlive invariant")
 }
 
+func TestClientHTTPClientEscapeHatch(t *testing.T) {
+	custom := &http.Client{Timeout: 99 * time.Second}
+	client, err := NewClient(
+		"apiKey", "apiSecret",
+		WithHTTPClient(custom),
+		// These should all be ignored:
+		WithMaxConnsPerHost(99),
+		WithIdleTimeout(99*time.Second),
+		WithConnectTimeout(99*time.Second),
+		WithRequestTimeout(99*time.Second),
+	)
+	require.NoError(t, err)
+
+	got := client.HttpClient().(*http.Client)
+	assert.Same(t, custom, got, "WithHTTPClient is the source of truth")
+	assert.Equal(t, 99*time.Second, got.Timeout, "user-supplied client's Timeout untouched")
+	assert.Nil(t, got.Transport, "SDK MUST NOT install a Transport on a user-supplied client")
+}
+
 func TestClientGetters(t *testing.T) {
 	customLogger := NewDefaultLogger(os.Stderr, "", log.LstdFlags, LogLevelInfo)
 	client, err := NewClient("apiKey", "apiSecret", WithLogger(customLogger))

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -263,7 +264,8 @@ func TestClientInfoLogOnConstruction(t *testing.T) {
 
 func TestClientInfoLogWithUserHTTPClient(t *testing.T) {
 	cap := &captureLogger{}
-	_, err := NewClient("apiKey", "apiSecret",
+	_, err := NewClient(
+		"apiKey", "apiSecret",
 		WithLogger(cap),
 		WithHTTPClient(&http.Client{Timeout: time.Second}),
 	)
@@ -286,6 +288,31 @@ func TestClientGetters(t *testing.T) {
 	assert.Equal(t, "apiKey", client.ApiKey())
 	assert.Equal(t, "https://chat.stream-io-api.com", client.BaseUrl())
 	assert.Equal(t, 30*time.Second, client.DefaultTimeout())
+}
+
+func TestClientPerCallTimeoutOverride(t *testing.T) {
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(200)
+	}))
+	defer slowServer.Close()
+
+	client, err := NewClient("apiKey", "apiSecret",
+		WithBaseUrl(slowServer.URL),
+		WithRequestTimeout(30*time.Second),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	req, _ := http.NewRequestWithContext(ctx, "GET", slowServer.URL, nil)
+	_, err = client.HttpClient().Do(req)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "expected context deadline exceeded")
+	assert.Less(t, elapsed, 500*time.Millisecond, "per-call ctx beats client timeout")
 }
 
 // TestCRUDCallTypeOperations tests Create, Read, Update, and Delete operations for call types.

--- a/examples_test.go
+++ b/examples_test.go
@@ -388,3 +388,18 @@ func TestCall_AutoFrameRecording(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "auto-on", resp.Data.Settings.FrameRecording.Mode)
 }
+
+func ExampleNewClient_withConnectionPoolTuning() {
+	client, err := getstream.NewClient(
+		"apiKey", "apiSecret",
+		getstream.WithMaxConnsPerHost(10),
+		getstream.WithIdleTimeout(55*time.Second),
+		getstream.WithConnectTimeout(5*time.Second),
+		getstream.WithRequestTimeout(20*time.Second),
+	)
+	if err != nil {
+		panic(err)
+	}
+	_ = client
+	// Output:
+}

--- a/webhook.go
+++ b/webhook.go
@@ -217,7 +217,7 @@ var ErrInvalidWebhook = errors.New("stream: invalid webhook")
 // route to UnknownEvent.
 var ErrUnknownEventType = errors.New("stream: unknown webhook event type")
 
-// gzipMagic is the two-byte gzip magic prefix (RFC 1952 §2.3.1).
+// gzipMagic is the two-byte gzip magic prefix (RFC 1952).
 // JSON cannot start with these bytes, so this gives unambiguous detection
 // for Stream's always-JSON payloads.
 var gzipMagic = []byte{0x1F, 0x8B}

--- a/webhook.go
+++ b/webhook.go
@@ -217,8 +217,9 @@ var ErrInvalidWebhook = errors.New("stream: invalid webhook")
 // route to UnknownEvent.
 var ErrUnknownEventType = errors.New("stream: unknown webhook event type")
 
-// gzipMagic is the two-byte gzip magic prefix (RFC 1952).
-// JSON cannot start with these bytes, so this gives unambiguous detection for Stream's always-JSON payloads.
+// gzipMagic is the two-byte gzip magic prefix (RFC 1952 §2.3.1).
+// JSON cannot start with these bytes, so this gives unambiguous detection
+// for Stream's always-JSON payloads.
 var gzipMagic = []byte{0x1F, 0x8B}
 
 // GetEventType extracts the event type from a raw webhook payload.
@@ -670,7 +671,7 @@ func VerifySignature(body []byte, signature, secret string) bool {
 //
 // Detection is by the first two bytes (0x1F 0x8B). This is reliable because
 // Stream webhook bodies are always JSON, and JSON's first byte is always
-// '{', '[', '"', a digit, '-', or one of t/f/n/whitespace, never 0x1F.
+// '{', '[', '"', a digit, '-', or one of t/f/n/whitespace — never 0x1F.
 //
 // Returns ErrInvalidWebhook (wrapped) if body has the gzip magic prefix
 // but isn't a valid gzip stream.
@@ -700,12 +701,12 @@ func GunzipPayload(body []byte) ([]byte, error) {
 // fails and we fall through to raw bytes, then GunzipPayload's magic-byte
 // detection decides whether to decompress.
 //
-// ParseSqs sits on top of this and works transparently for both wire formats:
-// no caller code change, no flag, no header.
+// ParseSqs sits on top of this and works transparently for both wire formats
+// — no caller code change, no flag, no header.
 func DecodeSqsPayload(messageBody string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(messageBody)
 	if err != nil {
-		// Not base64, so treat input as raw bytes (uncompressed wire format).
+		// Not base64 — treat input as raw bytes (uncompressed wire format).
 		decoded = []byte(messageBody)
 	}
 	return GunzipPayload(decoded)
@@ -716,7 +717,7 @@ func DecodeSqsPayload(messageBody string) ([]byte, error) {
 // a pre-extracted Message string flows through.
 //
 // Heuristic: try to JSON-parse the input. If it yields an object with a string
-// Message field, that's the envelope shape; return the Message. Otherwise the
+// Message field, that's the envelope shape — return the Message. Otherwise the
 // input is presumed to BE the pre-extracted Message (base64-encoded bytes are
 // not valid JSON, so this falls through cleanly).
 func unwrapSNSNotificationBody(body string) string {

--- a/webhook.go
+++ b/webhook.go
@@ -671,7 +671,7 @@ func VerifySignature(body []byte, signature, secret string) bool {
 //
 // Detection is by the first two bytes (0x1F 0x8B). This is reliable because
 // Stream webhook bodies are always JSON, and JSON's first byte is always
-// '{', '[', '"', a digit, '-', or one of t/f/n/whitespace — never 0x1F.
+// '{', '[', '"', a digit, '-', or one of t/f/n/whitespace; never 0x1F.
 //
 // Returns ErrInvalidWebhook (wrapped) if body has the gzip magic prefix
 // but isn't a valid gzip stream.
@@ -701,12 +701,12 @@ func GunzipPayload(body []byte) ([]byte, error) {
 // fails and we fall through to raw bytes, then GunzipPayload's magic-byte
 // detection decides whether to decompress.
 //
-// ParseSqs sits on top of this and works transparently for both wire formats
-// — no caller code change, no flag, no header.
+// ParseSqs sits on top of this and works transparently for both wire formats:
+// no caller code change, no flag, no header.
 func DecodeSqsPayload(messageBody string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(messageBody)
 	if err != nil {
-		// Not base64 — treat input as raw bytes (uncompressed wire format).
+		// Not base64, so treat input as raw bytes (uncompressed wire format).
 		decoded = []byte(messageBody)
 	}
 	return GunzipPayload(decoded)
@@ -717,7 +717,7 @@ func DecodeSqsPayload(messageBody string) ([]byte, error) {
 // a pre-extracted Message string flows through.
 //
 // Heuristic: try to JSON-parse the input. If it yields an object with a string
-// Message field, that's the envelope shape — return the Message. Otherwise the
+// Message field, that's the envelope shape; return the Message. Otherwise the
 // input is presumed to BE the pre-extracted Message (base64-encoded bytes are
 // not valid JSON, so this falls through cleanly).
 func unwrapSNSNotificationBody(body string) string {

--- a/webhook.go
+++ b/webhook.go
@@ -670,7 +670,7 @@ func VerifySignature(body []byte, signature, secret string) bool {
 //
 // Detection is by the first two bytes (0x1F 0x8B). This is reliable because
 // Stream webhook bodies are always JSON, and JSON's first byte is always
-// '{', '[', '"', a digit, '-', or one of t/f/n/whitespace — never 0x1F.
+// '{', '[', '"', a digit, '-', or one of t/f/n/whitespace, never 0x1F.
 //
 // Returns ErrInvalidWebhook (wrapped) if body has the gzip magic prefix
 // but isn't a valid gzip stream.
@@ -700,12 +700,12 @@ func GunzipPayload(body []byte) ([]byte, error) {
 // fails and we fall through to raw bytes, then GunzipPayload's magic-byte
 // detection decides whether to decompress.
 //
-// ParseSqs sits on top of this and works transparently for both wire formats
-// — no caller code change, no flag, no header.
+// ParseSqs sits on top of this and works transparently for both wire formats:
+// no caller code change, no flag, no header.
 func DecodeSqsPayload(messageBody string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(messageBody)
 	if err != nil {
-		// Not base64 — treat input as raw bytes (uncompressed wire format).
+		// Not base64, so treat input as raw bytes (uncompressed wire format).
 		decoded = []byte(messageBody)
 	}
 	return GunzipPayload(decoded)
@@ -716,7 +716,7 @@ func DecodeSqsPayload(messageBody string) ([]byte, error) {
 // a pre-extracted Message string flows through.
 //
 // Heuristic: try to JSON-parse the input. If it yields an object with a string
-// Message field, that's the envelope shape — return the Message. Otherwise the
+// Message field, that's the envelope shape; return the Message. Otherwise the
 // input is presumed to BE the pre-extracted Message (base64-encoded bytes are
 // not valid JSON, so this falls through cleanly).
 func unwrapSNSNotificationBody(body string) string {

--- a/webhook.go
+++ b/webhook.go
@@ -218,8 +218,7 @@ var ErrInvalidWebhook = errors.New("stream: invalid webhook")
 var ErrUnknownEventType = errors.New("stream: unknown webhook event type")
 
 // gzipMagic is the two-byte gzip magic prefix (RFC 1952).
-// JSON cannot start with these bytes, so this gives unambiguous detection
-// for Stream's always-JSON payloads.
+// JSON cannot start with these bytes, so this gives unambiguous detection for Stream's always-JSON payloads.
 var gzipMagic = []byte{0x1F, 0x8B}
 
 // GetEventType extracts the event type from a raw webhook payload.


### PR DESCRIPTION
## Summary

Adds explicit HTTP connection pool configuration to getstream-go.

- 4 new `With*` options: `WithMaxConnsPerHost`, `WithIdleTimeout`, `WithConnectTimeout`, `WithRequestTimeout`
- Defaults: 5 / 55s / 10s / 30s
- INFO log on construction lists the effective pool config
- `WithHTTPClient` escape hatch unchanged; when set, it bypasses all 4 new options

## Behavior change

Default `RequestTimeout` moves from 6s to 30s. Existing callers using `WithTimeout(...)` are unaffected. CHANGELOG calls this out under "Behavior changes."

## Test plan

- [x] Defaults assertions
- [x] Each knob individually overridable
- [x] `WithHTTPClient` escape hatch (`Transport` untouched, `Timeout` preserved)
- [x] INFO log with and without user-supplied http.Client
- [x] Per-call `context.WithTimeout` pre-empts client RequestTimeout
- [x] Example compiles + runs
- [x] `make lint` clean
- [x] `make build` clean

## Refs

- Linear: [CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)
