### PR TITLE
feat: [CHA-2958] standardize error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
+* Standardized error handling per the Server-Side SDK Error Handling Spec ([CHA-2958](https://linear.app/stream/issue/CHA-2958)).
+  * Four sentinel error categories on the existing `*StreamError`: `ErrApiResponse`, `ErrRateLimited`, `ErrTransport`, `ErrTaskFailed`. Use `errors.Is(err, ...)` to branch and `errors.As(err, &streamErr)` to extract typed fields. `ErrRateLimited` also satisfies `errors.Is(err, ErrApiResponse)`.
+  * New fields on `StreamError`: `Unrecoverable`, `Details`, `RawResponseBody`, `RetryAfter`, `ErrorType`, `Task`. No existing field accesses change.
+  * Transport-layer failures (connection reset / refused, timeout, DNS, TLS, broken pipe) are now wrapped at the HTTP-client boundary into `*StreamError` with `ErrTransport`; the original error is preserved via `errors.Unwrap`. `ErrorType` is one of `connection_reset`, `timeout`, `dns_failure`, `tls_handshake_failed`, `unknown` (matches the logging spec error.type enum).
+  * `Retry-After` response header is parsed on HTTP 429 (both RFC 7231 §7.1.3 integer-seconds and HTTP-date forms) and exposed as `StreamError.RetryAfter`. Auto-retry is **not** part of this SDK; callers compose their own retry strategy using `RetryAfter` and `Unrecoverable`.
+  * Unparseable error bodies (HTTP response received but JSON envelope malformed or absent) surface as `ErrApiResponse` with `code=0`, `Message="failed to parse error response"`, and the raw body preserved on `RawResponseBody`. The JSON parse error is reachable via the cause chain.
+  * New public helper `WaitForTask(ctx, client, taskID, opts...)` polls the task-status endpoint until terminal state. On `status="failed"` returns `*StreamError` with `ErrTaskFailed` and `Task` populated from the backend's `ErrorResult`. On timeout / context cancellation returns `*StreamError` with `ErrTransport` and `ErrorType="timeout"`. Defaults: 1s poll interval, 60s wait timeout — override with `WithWaitForTaskPollInterval` / `WithWaitForTaskTimeout`.
+  * Internal `stack.Wrap` helper (~30 lines, `runtime.Caller`-based, no external dependency) replaces `fmt.Errorf("...: %w", err)` in every user-facing path. `fmt.Sprintf("%+v", err)` now prints the captured wrap site for any error produced by the SDK.
+
 * Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
   Four new functional options:
     * `WithMaxConnsPerHost(int)`: default `5`

--- a/chat_channel_integration_test.go
+++ b/chat_channel_integration_test.go
@@ -178,7 +178,7 @@ func TestChatChannelIntegration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Data.TaskID)
 
-		taskResult, err := WaitForTask(ctx, client, *resp.Data.TaskID)
+		taskResult, err := waitForTaskInTests(ctx, client, *resp.Data.TaskID)
 		require.NoError(t, err)
 		require.Equal(t, "completed", taskResult.Data.Status)
 	})

--- a/chat_misc_integration_test.go
+++ b/chat_misc_integration_test.go
@@ -858,7 +858,7 @@ func TestChatExportChannelsIntegration(t *testing.T) {
 	assert.NotEmpty(t, exportResp.Data.TaskID)
 
 	// Wait for the export task to complete
-	taskResult, err := WaitForTask(ctx, client, exportResp.Data.TaskID)
+	taskResult, err := waitForTaskInTests(ctx, client, exportResp.Data.TaskID)
 	require.NoError(t, err)
 	assert.Equal(t, "completed", taskResult.Data.Status)
 }
@@ -903,7 +903,7 @@ func TestChatRestoreUsersIntegration(t *testing.T) {
 	assert.NotEmpty(t, delResp.Data.TaskID)
 
 	// Wait for deletion to complete
-	taskResult, err := WaitForTask(ctx, client, delResp.Data.TaskID)
+	taskResult, err := waitForTaskInTests(ctx, client, delResp.Data.TaskID)
 	require.NoError(t, err)
 	assert.Equal(t, "completed", taskResult.Data.Status)
 
@@ -1204,7 +1204,7 @@ func TestChatExportUsersIntegration(t *testing.T) {
 	require.NotEmpty(t, resp.Data.TaskID)
 
 	// Poll for task completion
-	taskResult, err := WaitForTask(ctx, client, resp.Data.TaskID)
+	taskResult, err := waitForTaskInTests(ctx, client, resp.Data.TaskID)
 	require.NoError(t, err)
 	assert.Equal(t, "completed", taskResult.Data.Status)
 }

--- a/chat_user_integration_test.go
+++ b/chat_user_integration_test.go
@@ -238,7 +238,7 @@ func TestChatUserIntegration(t *testing.T) {
 		taskID := resp.Data.TaskID
 		require.NotEmpty(t, taskID, "Task ID should not be empty")
 
-		taskResult, err := WaitForTask(ctx, client, taskID)
+		taskResult, err := waitForTaskInTests(ctx, client, taskID)
 		require.NoError(t, err)
 		assert.Equal(t, "completed", taskResult.Data.Status)
 	})
@@ -497,7 +497,7 @@ func TestChatUserIntegration(t *testing.T) {
 		assert.NotEmpty(t, resp.Data.TaskID)
 
 		// Wait for deactivation task
-		taskResult, err := WaitForTask(ctx, client, resp.Data.TaskID)
+		taskResult, err := waitForTaskInTests(ctx, client, resp.Data.TaskID)
 		require.NoError(t, err)
 		assert.Equal(t, "completed", taskResult.Data.Status)
 

--- a/client_test.go
+++ b/client_test.go
@@ -711,7 +711,7 @@ func TestVideoExamplesAdditional(t *testing.T) {
 		assert.NoError(t, err)
 		taskID := response.Data.TaskID
 
-		taskStatus, err := WaitForTask(ctx, client, taskID)
+		taskStatus, err := waitForTaskInTests(ctx, client, taskID)
 		assert.NoError(t, err)
 
 		if taskStatus.Data.Status == "completed" {
@@ -1059,7 +1059,7 @@ func TestHardDeleteCall(t *testing.T) {
 
 		require.NotNil(t, taskID)
 
-		taskStatus, err := WaitForTask(ctx, client, *taskID)
+		taskStatus, err := waitForTaskInTests(ctx, client, *taskID)
 		assert.NoError(t, err)
 
 		if taskStatus.Data.Status == "completed" {

--- a/errors.go
+++ b/errors.go
@@ -11,16 +11,15 @@ import (
 	"time"
 )
 
-// Sentinel errors expose the SDK error categories defined by the
-// Server-Side SDK Error Handling Spec §4.2 (Go expression). All concrete
-// errors returned from the SDK are *StreamError; callers branch on
-// category with errors.Is(err, sentinel) and extract structured fields with
+// Sentinel errors expose the SDK error categories. All concrete errors
+// returned from the SDK are *StreamError; callers branch on category
+// with errors.Is(err, sentinel) and extract structured fields with
 // errors.As(err, &streamErr).
 var (
 	// ErrApiResponse fires when the backend returned an HTTP 4xx/5xx
 	// (auth, validation, server error, or any other API failure with the
-	// APIError envelope). Also satisfied by ErrRateLimited via the spec
-	// §4.2 wrap chain.
+	// APIError envelope). Also satisfied by ErrRateLimited via the
+	// Unwrap chain.
 	ErrApiResponse = errors.New("stream: api error")
 
 	// ErrRateLimited fires when the backend returned HTTP 429.
@@ -40,7 +39,7 @@ var (
 )
 
 // Transport-error subtype values populated on StreamError.ErrorType when the
-// sentinel is ErrTransport. Mirrors the logging spec §6.4 error.type enum.
+// sentinel is ErrTransport.
 const (
 	ErrorTypeConnectionReset = "connection_reset"
 	ErrorTypeTimeout         = "timeout"
@@ -59,9 +58,9 @@ type TaskErrorDetails struct {
 	Version     string
 }
 
-// classifyTransportError maps a transport-layer error to the spec §6.1
-// errorType enum. The mapping inspects the error chain via errors.Is /
-// errors.As so it survives library wrapping.
+// classifyTransportError maps a transport-layer error to an errorType
+// enum. The mapping inspects the error chain via errors.Is / errors.As
+// so it survives library wrapping.
 func classifyTransportError(err error) string {
 	if err == nil {
 		return ErrorTypeUnknown
@@ -130,7 +129,7 @@ func wrapTransportError(err error) *StreamError {
 
 // parseRetryAfter parses an HTTP Retry-After header value per RFC 7231 §7.1.3.
 // Accepts either a non-negative integer in seconds or an HTTP-date. Returns 0
-// if the header is missing or unparseable (no error — graceful per spec §7).
+// if the header is missing or unparseable.
 //
 // now is injectable for deterministic tests; pass time.Now in production.
 func parseRetryAfter(value string, now time.Time) time.Duration {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,158 @@
+package getstream
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Sentinel errors expose the SDK error categories defined by the
+// Server-Side SDK Error Handling Spec §4.2 (Go expression). All concrete
+// errors returned from the SDK are *StreamError; callers branch on
+// category with errors.Is(err, sentinel) and extract structured fields with
+// errors.As(err, &streamErr).
+var (
+	// ErrApiResponse fires when the backend returned an HTTP 4xx/5xx
+	// (auth, validation, server error, or any other API failure with the
+	// APIError envelope). Also satisfied by ErrRateLimited via the spec
+	// §4.2 wrap chain.
+	ErrApiResponse = errors.New("stream: api error")
+
+	// ErrRateLimited fires when the backend returned HTTP 429.
+	// StreamError.RetryAfter carries the parsed Retry-After header.
+	// errors.Is(err, ErrApiResponse) also returns true.
+	ErrRateLimited = errors.New("stream: rate limited")
+
+	// ErrTransport fires when a network-layer failure prevented an HTTP
+	// response from being received (connection reset, timeout, TLS,
+	// DNS). StreamError.ErrorType identifies the subtype; the original
+	// error is preserved via errors.Unwrap.
+	ErrTransport = errors.New("stream: transport error")
+
+	// ErrTaskFailed fires when WaitForTask observes status=="failed".
+	// StreamError.Task carries the task's ErrorResult.
+	ErrTaskFailed = errors.New("stream: task failed")
+)
+
+// Transport-error subtype values populated on StreamError.ErrorType when the
+// sentinel is ErrTransport. Mirrors the logging spec §6.4 error.type enum.
+const (
+	ErrorTypeConnectionReset = "connection_reset"
+	ErrorTypeTimeout         = "timeout"
+	ErrorTypeDNSFailure      = "dns_failure"
+	ErrorTypeTLSHandshake    = "tls_handshake_failed"
+	ErrorTypeUnknown         = "unknown"
+)
+
+// TaskErrorDetails carries the failed-task payload exposed on
+// StreamError.Task when the sentinel is ErrTaskFailed.
+type TaskErrorDetails struct {
+	TaskID      string
+	ErrorType   string
+	Description string
+	StackTrace  string
+	Version     string
+}
+
+// classifyTransportError maps a transport-layer error to the spec §6.1
+// errorType enum. The mapping inspects the error chain via errors.Is /
+// errors.As so it survives library wrapping.
+func classifyTransportError(err error) string {
+	if err == nil {
+		return ErrorTypeUnknown
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrorTypeTimeout
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return ErrorTypeTimeout
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return ErrorTypeDNSFailure
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if opErr.Op == "dial" {
+			if strings.Contains(opErr.Err.Error(), "no such host") {
+				return ErrorTypeDNSFailure
+			}
+		}
+	}
+
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "tls:"),
+		strings.Contains(msg, "x509:"),
+		strings.Contains(msg, "TLS handshake"):
+		return ErrorTypeTLSHandshake
+	case strings.Contains(msg, "connection reset"),
+		strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "broken pipe"),
+		strings.Contains(msg, "EOF"):
+		return ErrorTypeConnectionReset
+	case strings.Contains(msg, "no such host"):
+		return ErrorTypeDNSFailure
+	}
+
+	// url.Error often hides the actual cause; recurse into it.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil && urlErr.Err != err {
+		if sub := classifyTransportError(urlErr.Err); sub != ErrorTypeUnknown {
+			return sub
+		}
+	}
+
+	return ErrorTypeUnknown
+}
+
+// wrapTransportError converts a raw transport-layer error from the HTTP
+// client into a *StreamError with the ErrTransport sentinel, populated
+// ErrorType, and the original error preserved via stack-bearing wrap.
+func wrapTransportError(err error) *StreamError {
+	return &StreamError{
+		sentinel:  ErrTransport,
+		ErrorType: classifyTransportError(err),
+		Message:   "stream transport error: " + err.Error(),
+		cause:     stackWrap(err, "transport error"),
+	}
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value per RFC 7231 §7.1.3.
+// Accepts either a non-negative integer in seconds or an HTTP-date. Returns 0
+// if the header is missing or unparseable (no error — graceful per spec §7).
+//
+// now is injectable for deterministic tests; pass time.Now in production.
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+
+	if t, err := http.ParseTime(value); err == nil {
+		d := t.Sub(now)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+
+	return 0
+}

--- a/errors_stack.go
+++ b/errors_stack.go
@@ -18,12 +18,10 @@ type stackErr struct {
 	n     int
 }
 
-// stackWrap wraps err with a contextual message and captures a stack trace
-// at the call site. Returns nil if err is nil.
-//
-// This is the Go SDK's mandated wrapper for user-facing error paths
-// (Server-Side SDK Error Handling Spec §6.5). fmt.Errorf("...: %w", err)
-// is forbidden in those paths because it loses the wrap site.
+// stackWrap wraps err with the call site captured via runtime.Callers.
+// The wrap site is rendered by Format("%+v") and accessible via
+// StackTrace(). Use stackWrap instead of fmt.Errorf("...: %w", ...) in
+// user-facing paths so the original wrap site survives the cause chain.
 func stackWrap(err error, msg string) error {
 	if err == nil {
 		return nil

--- a/errors_stack.go
+++ b/errors_stack.go
@@ -1,0 +1,85 @@
+package getstream
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+)
+
+// stackErr wraps an error with a single captured stack frame at the
+// wrap site. It is fully compatible with errors.Is / errors.As / errors.Unwrap.
+//
+// The %+v verb on fmt.Sprintf prints the full chain including the captured
+// frame; %v / %s print only the formatted message of this layer.
+type stackErr struct {
+	msg   string
+	cause error
+	pc    [32]uintptr
+	n     int
+}
+
+// stackWrap wraps err with a contextual message and captures a stack trace
+// at the call site. Returns nil if err is nil.
+//
+// This is the Go SDK's mandated wrapper for user-facing error paths
+// (Server-Side SDK Error Handling Spec §6.5). fmt.Errorf("...: %w", err)
+// is forbidden in those paths because it loses the wrap site.
+func stackWrap(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	se := &stackErr{msg: msg, cause: err}
+	se.n = runtime.Callers(2, se.pc[:])
+	return se
+}
+
+func (e *stackErr) Error() string {
+	if e.msg == "" {
+		return e.cause.Error()
+	}
+	return e.msg + ": " + e.cause.Error()
+}
+
+func (e *stackErr) Unwrap() error { return e.cause }
+
+// StackTrace returns the captured frames as "func\n\tfile:line" entries.
+// Returns nil if no frames were captured.
+func (e *stackErr) StackTrace() []string {
+	if e.n == 0 {
+		return nil
+	}
+	frames := runtime.CallersFrames(e.pc[:e.n])
+	var out []string
+	for {
+		f, more := frames.Next()
+		if f.Function != "" || f.File != "" {
+			out = append(out, fmt.Sprintf("%s\n\t%s:%d", f.Function, f.File, f.Line))
+		}
+		if !more {
+			break
+		}
+	}
+	return out
+}
+
+// Format implements fmt.Formatter. The %+v verb prints message + stack frames
+// plus the wrapped cause (recursively if the cause also implements %+v).
+// %v / %s print the flat error string.
+func (e *stackErr) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = io.WriteString(s, e.Error())
+			for _, frame := range e.StackTrace() {
+				_, _ = io.WriteString(s, "\n")
+				_, _ = io.WriteString(s, frame)
+			}
+			return
+		}
+		fallthrough
+	case 's':
+		_, _ = io.WriteString(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	}
+}

--- a/errors_stack_test.go
+++ b/errors_stack_test.go
@@ -1,0 +1,69 @@
+package getstream
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestStackWrap_NilCause(t *testing.T) {
+	if got := stackWrap(nil, "msg"); got != nil {
+		t.Fatalf("stackWrap(nil) = %v, want nil", got)
+	}
+}
+
+func TestStackWrap_PreservesUnwrapChain(t *testing.T) {
+	sentinel := errors.New("root cause")
+	wrapped := stackWrap(sentinel, "outer")
+
+	if !errors.Is(wrapped, sentinel) {
+		t.Fatalf("errors.Is should reach the wrapped sentinel; chain broken")
+	}
+	if got := errors.Unwrap(wrapped).Error(); got != "root cause" {
+		t.Fatalf("Unwrap = %q, want %q", got, "root cause")
+	}
+}
+
+func TestStackWrap_ErrorString(t *testing.T) {
+	wrapped := stackWrap(errors.New("inner"), "outer")
+	if got := wrapped.Error(); got != "outer: inner" {
+		t.Fatalf("Error() = %q, want %q", got, "outer: inner")
+	}
+}
+
+func TestStackWrap_PlusVFormatIncludesStack(t *testing.T) {
+	wrapped := stackWrap(errors.New("inner"), "outer")
+	formatted := fmt.Sprintf("%+v", wrapped)
+
+	if !strings.Contains(formatted, "outer: inner") {
+		t.Fatalf("%%+v output missing flat message: %q", formatted)
+	}
+	if !strings.Contains(formatted, "errors_stack_test.go") {
+		t.Fatalf("%%+v output missing stack frame referencing the wrap site: %q", formatted)
+	}
+}
+
+func TestStackWrap_VFormatNoStack(t *testing.T) {
+	wrapped := stackWrap(errors.New("inner"), "outer")
+	formatted := fmt.Sprintf("%v", wrapped)
+	if formatted != "outer: inner" {
+		t.Fatalf("%%v output = %q, want %q", formatted, "outer: inner")
+	}
+}
+
+func TestStackWrap_StackTraceAccessor(t *testing.T) {
+	wrapped := stackWrap(errors.New("inner"), "outer")
+	var se *stackErr
+	if !errors.As(wrapped, &se) {
+		t.Fatalf("errors.As did not extract *stackErr")
+	}
+	frames := se.StackTrace()
+	if len(frames) == 0 {
+		t.Fatalf("StackTrace() empty, expected at least one frame")
+	}
+	// First frame should be in this test file.
+	if !strings.Contains(frames[0], "errors_stack_test.go") {
+		t.Fatalf("first frame = %q, want errors_stack_test.go", frames[0])
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -157,7 +157,10 @@ func TestClassifyTransportError(t *testing.T) {
 	dnsErr := &net.DNSError{Err: "no such host", Name: "example.invalid"}
 	timeoutErr := &net.OpError{Op: "read", Err: timeoutError{}}
 	resetErr := errors.New("read tcp 127.0.0.1:1234: connection reset by peer")
-	tlsErr := &tls.CertificateVerificationError{UnverifiedCertificates: []*x509.Certificate{}}
+	// `tls.CertificateVerificationError` is only available from Go 1.20+.
+	// Use a generic error whose message the classifier matches via substring,
+	// so the test works on Go 1.19 and newer.
+	tlsErr := errors.New("tls: handshake failure: certificate verify failed")
 	refusedErr := errors.New("dial tcp 127.0.0.1:1: connection refused")
 
 	tests := []struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,307 @@
+package getstream
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStreamError_Is_Sentinels(t *testing.T) {
+	tests := []struct {
+		name     string
+		sentinel error
+		targets  []error
+		want     map[error]bool
+	}{
+		{
+			name:     "ErrApiResponse only",
+			sentinel: ErrApiResponse,
+			targets:  []error{ErrApiResponse, ErrRateLimited, ErrTransport, ErrTaskFailed},
+			want: map[error]bool{
+				ErrApiResponse: true,
+				ErrRateLimited: false,
+				ErrTransport:   false,
+				ErrTaskFailed:  false,
+			},
+		},
+		{
+			name:     "ErrRateLimited also satisfies ErrApiResponse",
+			sentinel: ErrRateLimited,
+			targets:  []error{ErrApiResponse, ErrRateLimited, ErrTransport, ErrTaskFailed},
+			want: map[error]bool{
+				ErrApiResponse: true,
+				ErrRateLimited: true,
+				ErrTransport:   false,
+				ErrTaskFailed:  false,
+			},
+		},
+		{
+			name:     "ErrTransport only",
+			sentinel: ErrTransport,
+			targets:  []error{ErrApiResponse, ErrRateLimited, ErrTransport, ErrTaskFailed},
+			want: map[error]bool{
+				ErrApiResponse: false,
+				ErrRateLimited: false,
+				ErrTransport:   true,
+				ErrTaskFailed:  false,
+			},
+		},
+		{
+			name:     "ErrTaskFailed only",
+			sentinel: ErrTaskFailed,
+			targets:  []error{ErrApiResponse, ErrRateLimited, ErrTransport, ErrTaskFailed},
+			want: map[error]bool{
+				ErrApiResponse: false,
+				ErrRateLimited: false,
+				ErrTransport:   false,
+				ErrTaskFailed:  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &StreamError{sentinel: tt.sentinel, Message: "x"}
+			var e error = err
+			for _, target := range tt.targets {
+				got := errors.Is(e, target)
+				if got != tt.want[target] {
+					t.Errorf("errors.Is(err, %v) = %v, want %v", target, got, tt.want[target])
+				}
+			}
+		})
+	}
+}
+
+func TestStreamError_As_ExtractsStruct(t *testing.T) {
+	original := &StreamError{
+		sentinel:        ErrApiResponse,
+		StatusCode:      404,
+		Code:            17,
+		Message:         "not found",
+		ExceptionFields: map[string]string{},
+	}
+	var err error = original
+
+	var got *StreamError
+	if !errors.As(err, &got) {
+		t.Fatalf("errors.As(*StreamError) returned false")
+	}
+	if got.StatusCode != 404 || got.Code != 17 || got.Message != "not found" {
+		t.Errorf("extracted struct mismatch: %+v", got)
+	}
+}
+
+func TestStreamError_UnwrapReturnsCause(t *testing.T) {
+	root := errors.New("network closed")
+	err := &StreamError{
+		sentinel: ErrTransport,
+		cause:    stackWrap(root, "transport error"),
+		Message:  "transport",
+	}
+	if !errors.Is(err, root) {
+		t.Fatalf("errors.Is(err, root) returned false; cause chain broken")
+	}
+}
+
+func TestParseRetryAfter_Integer(t *testing.T) {
+	got := parseRetryAfter("30", time.Now())
+	want := 30 * time.Second
+	if got != want {
+		t.Fatalf("parseRetryAfter(\"30\") = %v, want %v", got, want)
+	}
+}
+
+func TestParseRetryAfter_HTTPDate(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	header := now.Add(45 * time.Second).UTC().Format(http.TimeFormat)
+	got := parseRetryAfter(header, now)
+	if got < 44*time.Second || got > 46*time.Second {
+		t.Fatalf("parseRetryAfter(http-date) = %v, want ~45s", got)
+	}
+}
+
+func TestParseRetryAfter_NegativeIntegerClamps(t *testing.T) {
+	if got := parseRetryAfter("-5", time.Now()); got != 0 {
+		t.Fatalf("parseRetryAfter(\"-5\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfter_PastHTTPDateClamps(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	header := now.Add(-time.Hour).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(header, now); got != 0 {
+		t.Fatalf("parseRetryAfter(past-date) = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfter_EmptyAndJunk(t *testing.T) {
+	now := time.Now()
+	cases := []string{"", "  ", "soon", "1d"}
+	for _, c := range cases {
+		if got := parseRetryAfter(c, now); got != 0 {
+			t.Errorf("parseRetryAfter(%q) = %v, want 0", c, got)
+		}
+	}
+}
+
+func TestClassifyTransportError(t *testing.T) {
+	dnsErr := &net.DNSError{Err: "no such host", Name: "example.invalid"}
+	timeoutErr := &net.OpError{Op: "read", Err: timeoutError{}}
+	resetErr := errors.New("read tcp 127.0.0.1:1234: connection reset by peer")
+	tlsErr := &tls.CertificateVerificationError{UnverifiedCertificates: []*x509.Certificate{}}
+	refusedErr := errors.New("dial tcp 127.0.0.1:1: connection refused")
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"dns", dnsErr, ErrorTypeDNSFailure},
+		{"timeout", timeoutErr, ErrorTypeTimeout},
+		{"context deadline exceeded", context.DeadlineExceeded, ErrorTypeTimeout},
+		{"connection reset", resetErr, ErrorTypeConnectionReset},
+		{"connection refused", refusedErr, ErrorTypeConnectionReset},
+		{"tls", tlsErr, ErrorTypeTLSHandshake},
+		{"unknown", errors.New("something weird"), ErrorTypeUnknown},
+		{"nil", nil, ErrorTypeUnknown},
+		{
+			name: "url.Error wrapping timeout",
+			err:  &url.Error{Op: "Get", URL: "https://x", Err: timeoutError{}},
+			want: ErrorTypeTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyTransportError(tt.err); got != tt.want {
+				t.Errorf("classifyTransportError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapTransportError_FieldsAndSentinel(t *testing.T) {
+	root := errors.New("read tcp 1.2.3.4:5: connection reset by peer")
+	err := wrapTransportError(root)
+
+	if !errors.Is(err, ErrTransport) {
+		t.Errorf("errors.Is(err, ErrTransport) = false")
+	}
+	if err.ErrorType != ErrorTypeConnectionReset {
+		t.Errorf("ErrorType = %v, want %v", err.ErrorType, ErrorTypeConnectionReset)
+	}
+	if !errors.Is(err, root) {
+		t.Errorf("errors.Is(err, root) = false; cause chain broken")
+	}
+	if !strings.Contains(err.Error(), "connection reset by peer") {
+		t.Errorf("err.Error() = %q, want substring 'connection reset by peer'", err.Error())
+	}
+}
+
+func TestBuildAPIError_429PopulatesRetryAfter(t *testing.T) {
+	body := `{"code":9,"message":"rate limited","StatusCode":429}`
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			"Retry-After": []string{"42"},
+		},
+	}
+	got := buildAPIError(resp, []byte(body))
+
+	if !errors.Is(got, ErrRateLimited) {
+		t.Errorf("errors.Is(err, ErrRateLimited) = false")
+	}
+	if !errors.Is(got, ErrApiResponse) {
+		t.Errorf("ErrRateLimited should also match ErrApiResponse via §4.2")
+	}
+	if got.RetryAfter != 42*time.Second {
+		t.Errorf("RetryAfter = %v, want 42s", got.RetryAfter)
+	}
+	if got.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", got.StatusCode)
+	}
+	if got.Code != 9 {
+		t.Errorf("Code = %d, want 9", got.Code)
+	}
+	if got.RawResponseBody != body {
+		t.Errorf("RawResponseBody mismatch: got %q", got.RawResponseBody)
+	}
+}
+
+func TestBuildAPIError_UnparseableBodyPath(t *testing.T) {
+	body := `not json`
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{},
+	}
+	got := buildAPIError(resp, []byte(body))
+
+	if !errors.Is(got, ErrApiResponse) {
+		t.Errorf("unparseable body should map to ErrApiResponse, not transport")
+	}
+	if got.Code != 0 {
+		t.Errorf("Code = %d, want 0 for unparseable", got.Code)
+	}
+	if got.Message != "failed to parse error response" {
+		t.Errorf("Message = %q, want canonical unparseable text", got.Message)
+	}
+	if got.RawResponseBody != body {
+		t.Errorf("RawResponseBody = %q, want raw body preserved", got.RawResponseBody)
+	}
+	// Cause chain must carry the JSON-parse error.
+	var parseErr *json.SyntaxError
+	if !errors.As(got, &parseErr) {
+		t.Errorf("cause chain should carry the JSON parse error")
+	}
+}
+
+func TestBuildAPIError_PopulatesUnrecoverableAndDetails(t *testing.T) {
+	body := `{"code":4,"message":"bad request","StatusCode":400,"unrecoverable":true,"details":{"field":"value"},"more_info":"https://docs.example/4"}`
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+	}
+	got := buildAPIError(resp, []byte(body))
+
+	if !got.Unrecoverable {
+		t.Errorf("Unrecoverable = false, want true")
+	}
+	if got.MoreInfo != "https://docs.example/4" {
+		t.Errorf("MoreInfo = %q, want canonical", got.MoreInfo)
+	}
+	if len(got.Details) == 0 {
+		t.Errorf("Details empty, want preserved raw JSON")
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(got.Details, &decoded); err != nil {
+		t.Errorf("Details not valid JSON: %v", err)
+	}
+	if decoded["field"] != "value" {
+		t.Errorf("Details decoded mismatch: %v", decoded)
+	}
+}
+
+func TestBuildAPIError_EmptyExceptionFieldsAlwaysMap(t *testing.T) {
+	body := `{"code":1,"message":"x","StatusCode":500}`
+	resp := &http.Response{StatusCode: 500, Header: http.Header{}}
+	got := buildAPIError(resp, []byte(body))
+	if got.ExceptionFields == nil {
+		t.Fatalf("ExceptionFields nil; spec §5.1 mandates empty map when absent")
+	}
+}
+
+// timeoutError implements net.Error reporting Timeout=true.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,8 +2,6 @@ package getstream
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"net"

--- a/http.go
+++ b/http.go
@@ -41,7 +41,25 @@ func (c *Client) logResponse(resp *http.Response, body []byte, duration time.Dur
 	c.logger.Debug("\n%s", string(body))
 }
 
-// Error represents an API error
+// StreamError is the single concrete error type returned by the SDK.
+//
+// Category is signaled by the sentinel embedded via Is: callers branch with
+// errors.Is(err, ErrApiResponse | ErrRateLimited | ErrTransport | ErrTaskFailed)
+// and extract fields with errors.As(err, &streamErr). See
+// Server-Side SDK Error Handling Spec §4.2 / §5 for the field schema.
+//
+// Per-field population by sentinel:
+//
+//   - ErrApiResponse:  StatusCode, Code, Message, ExceptionFields, Unrecoverable,
+//     RawResponseBody, MoreInfo, Details, RateLimit, Duration are set from the
+//     APIError envelope. RetryAfter is zero. ErrorType is "". Task is nil.
+//   - ErrRateLimited:  same as ErrApiResponse + RetryAfter parsed from the
+//     Retry-After header (RFC 7231 §7.1.3). errors.Is(err, ErrApiResponse) also
+//     returns true.
+//   - ErrTransport:    Message and ErrorType are set; underlying transport
+//     error is reachable via errors.Unwrap. All API-envelope fields are zero.
+//   - ErrTaskFailed:   Task is set with the failed task's ErrorResult fields.
+//     All API-envelope fields are zero.
 type StreamError struct {
 	Code            int               `json:"code"`
 	Message         string            `json:"message"`
@@ -49,11 +67,71 @@ type StreamError struct {
 	StatusCode      int               `json:"StatusCode"`
 	Duration        string            `json:"duration"`
 	MoreInfo        string            `json:"more_info"`
-	RateLimit       *RateLimitInfo    `json:"-"`
+	// Unrecoverable mirrors APIError.unrecoverable. When true, the request
+	// that produced this error must not be retried.
+	Unrecoverable bool `json:"unrecoverable,omitempty"`
+	// Details carries the opaque APIError.details payload verbatim. nil if
+	// the backend omitted the field.
+	Details json.RawMessage `json:"details,omitempty"`
+	// RawResponseBody is the unparsed response body. Always set on API-response
+	// errors (including the §6.3 unparseable-body case).
+	RawResponseBody string `json:"-"`
+	// RetryAfter is the parsed Retry-After header on HTTP 429. Zero otherwise.
+	RetryAfter time.Duration `json:"-"`
+	// ErrorType is populated only when the sentinel is ErrTransport. One of
+	// ErrorTypeConnectionReset, ErrorTypeTimeout, ErrorTypeDNSFailure,
+	// ErrorTypeTLSHandshake, ErrorTypeUnknown.
+	ErrorType string `json:"-"`
+	// Task carries the failed-task payload when the sentinel is ErrTaskFailed.
+	Task *TaskErrorDetails `json:"-"`
+	// RateLimit carries the rate-limit window info from response headers.
+	RateLimit *RateLimitInfo `json:"-"`
+
+	// sentinel selects the category surfaced via Is. cause is the wrapped
+	// underlying error (typically a stack-bearing wrapper).
+	sentinel error
+	cause    error
 }
 
-func (e StreamError) Error() string {
+func (e *StreamError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
 	return e.Message
+}
+
+// Is reports whether target matches the StreamError's category sentinel.
+// ErrRateLimited additionally matches ErrApiResponse per spec §4.2.
+func (e *StreamError) Is(target error) bool {
+	if e == nil || target == nil {
+		return false
+	}
+	if e.sentinel != nil && target == e.sentinel {
+		return true
+	}
+	if e.sentinel == ErrRateLimited && target == ErrApiResponse {
+		return true
+	}
+	return false
+}
+
+// Unwrap returns the underlying cause (typically a stack-bearing wrapper
+// over the original transport error or JSON-parse error). Returns nil for
+// API-response errors that have no upstream cause.
+func (e *StreamError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// Sentinel reports the category sentinel this error belongs to (e.g.
+// ErrApiResponse). Returns nil if no category was set.
+func (e *StreamError) Sentinel() error {
+	if e == nil {
+		return nil
+	}
+	return e.sentinel
 }
 
 // Response is the base response returned to the client
@@ -62,31 +140,67 @@ type StreamResponse[T any] struct {
 	Data          T
 }
 
-// parseResponse parses the HTTP response into the provided result
+// parseResponse parses the HTTP response into the provided result.
+// On HTTP 4xx/5xx returns a *StreamError populated per Server-Side SDK
+// Error Handling Spec §5/§6.
 func parseResponse[GResponse any](c *Client, resp *http.Response, body []byte, result *GResponse) (*StreamResponse[GResponse], error) {
 	statusCode := resp.StatusCode
 	c.logger.Debug("Status Code: %d", statusCode)
-	// If status code indicates an error
 	if statusCode >= 399 {
-		var apiErr StreamError
-		err := json.Unmarshal(body, &apiErr)
-		if err != nil {
-			apiErr.Message = string(body)
-			apiErr.StatusCode = resp.StatusCode
-			return nil, apiErr
-		}
-		apiErr.RateLimit = NewRateLimitFromHeaders(resp.Header)
-		return nil, apiErr
+		return nil, buildAPIError(resp, body)
 	}
 
-	// Attempt to unmarshal the response into the result
-	err := json.Unmarshal(body, result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
+	if err := json.Unmarshal(body, result); err != nil {
+		return nil, stackWrap(err, "failed to unmarshal response body")
 	}
 
-	// Add rate limit info to the result
 	return addRateLimitInfo(resp.Header, result)
+}
+
+// buildAPIError constructs a *StreamError for an HTTP 4xx/5xx response per
+// spec §6.2 (parsed APIError envelope) and §6.3 (unparseable body).
+func buildAPIError(resp *http.Response, body []byte) *StreamError {
+	apiErr := &StreamError{
+		StatusCode:      resp.StatusCode,
+		RawResponseBody: string(body),
+		ExceptionFields: map[string]string{},
+		RateLimit:       NewRateLimitFromHeaders(resp.Header),
+	}
+
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, apiErr); err != nil {
+			// §6.3 — HTTP response received but body unparseable. NOT a
+			// transport error (the HTTP layer succeeded).
+			apiErr.Code = 0
+			apiErr.Message = "failed to parse error response"
+			apiErr.ExceptionFields = map[string]string{}
+			apiErr.Unrecoverable = false
+			apiErr.cause = stackWrap(err, "parse api error response")
+			apiErr.sentinel = ErrApiResponse
+			return apiErr
+		}
+	} else {
+		apiErr.Message = "empty response body"
+	}
+
+	// json.Unmarshal overwrites StatusCode if the body carries the legacy
+	// uppercase "StatusCode" field, then leaves zero values for absent fields.
+	// Restore non-zero StatusCode and ExceptionFields from the response.
+	if apiErr.StatusCode == 0 {
+		apiErr.StatusCode = resp.StatusCode
+	}
+	if apiErr.ExceptionFields == nil {
+		apiErr.ExceptionFields = map[string]string{}
+	}
+
+	if apiErr.StatusCode == http.StatusTooManyRequests {
+		apiErr.sentinel = ErrRateLimited
+		apiErr.RetryAfter = parseRetryAfter(resp.Header.Get("Retry-After"), time.Now())
+	} else {
+		apiErr.sentinel = ErrApiResponse
+	}
+
+	return apiErr
 }
 
 // requestURL constructs the full request URL
@@ -95,7 +209,7 @@ func (c *Client) requestURL(path string, values url.Values, pathParams map[strin
 
 	u, err := url.Parse(c.baseUrl + path)
 	if err != nil {
-		return "", fmt.Errorf("url.Parse: %w", err)
+		return "", stackWrap(err, "url.Parse")
 	}
 
 	if values == nil {
@@ -187,7 +301,7 @@ func getFileContent(fileName string, fileContent io.Reader) (io.Reader, error) {
 	if fileName != "" {
 		file, err := os.Open(fileName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open file: %w", err)
+			return nil, stackWrap(err, "failed to open file")
 		}
 		return file, nil
 	}
@@ -211,18 +325,18 @@ func (c *Client) createMultipartRequest(r *http.Request, data any) (*http.Reques
 		fileName = *req.File
 		fileContent, err = getFileContent(*req.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open file: %w", err)
+			return nil, stackWrap(err, "failed to open file")
 		}
 
 		// Add user field if present
 		if req.User != nil {
 			userJSON, err := json.Marshal(req.User)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal user: %w", err)
+				return nil, stackWrap(err, "failed to marshal user")
 			}
 			err = writer.WriteField("user", string(userJSON))
 			if err != nil {
-				return nil, fmt.Errorf("failed to write user field: %w", err)
+				return nil, stackWrap(err, "failed to write user field")
 			}
 		}
 
@@ -233,18 +347,18 @@ func (c *Client) createMultipartRequest(r *http.Request, data any) (*http.Reques
 		fileName = *req.File
 		fileContent, err = getFileContent(*req.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open file: %w", err)
+			return nil, stackWrap(err, "failed to open file")
 		}
 
 		// Add upload_sizes field if present
 		if req.UploadSizes != nil && len(req.UploadSizes) > 0 {
 			uploadSizesJSON, err := json.Marshal(req.UploadSizes)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal upload_sizes: %w", err)
+				return nil, stackWrap(err, "failed to marshal upload_sizes")
 			}
 			err = writer.WriteField("upload_sizes", string(uploadSizesJSON))
 			if err != nil {
-				return nil, fmt.Errorf("failed to write upload_sizes field: %w", err)
+				return nil, stackWrap(err, "failed to write upload_sizes field")
 			}
 		}
 
@@ -252,11 +366,11 @@ func (c *Client) createMultipartRequest(r *http.Request, data any) (*http.Reques
 		if req.User != nil {
 			userJSON, err := json.Marshal(req.User)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal user: %w", err)
+				return nil, stackWrap(err, "failed to marshal user")
 			}
 			err = writer.WriteField("user", string(userJSON))
 			if err != nil {
-				return nil, fmt.Errorf("failed to write user field: %w", err)
+				return nil, stackWrap(err, "failed to write user field")
 			}
 		}
 
@@ -267,18 +381,18 @@ func (c *Client) createMultipartRequest(r *http.Request, data any) (*http.Reques
 		fileName = *req.File
 		fileContent, err = getFileContent(*req.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open file: %w", err)
+			return nil, stackWrap(err, "failed to open file")
 		}
 
 		// Add user field if present
 		if req.User != nil {
 			userJSON, err := json.Marshal(req.User)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal user: %w", err)
+				return nil, stackWrap(err, "failed to marshal user")
 			}
 			err = writer.WriteField("user", string(userJSON))
 			if err != nil {
-				return nil, fmt.Errorf("failed to write user field: %w", err)
+				return nil, stackWrap(err, "failed to write user field")
 			}
 		}
 
@@ -289,18 +403,18 @@ func (c *Client) createMultipartRequest(r *http.Request, data any) (*http.Reques
 		fileName = *req.File
 		fileContent, err = getFileContent(*req.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open file: %w", err)
+			return nil, stackWrap(err, "failed to open file")
 		}
 
 		// Add upload_sizes field if present
 		if req.UploadSizes != nil && len(req.UploadSizes) > 0 {
 			uploadSizesJSON, err := json.Marshal(req.UploadSizes)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal upload_sizes: %w", err)
+				return nil, stackWrap(err, "failed to marshal upload_sizes")
 			}
 			err = writer.WriteField("upload_sizes", string(uploadSizesJSON))
 			if err != nil {
-				return nil, fmt.Errorf("failed to write upload_sizes field: %w", err)
+				return nil, stackWrap(err, "failed to write upload_sizes field")
 			}
 		}
 
@@ -308,11 +422,11 @@ func (c *Client) createMultipartRequest(r *http.Request, data any) (*http.Reques
 		if req.User != nil {
 			userJSON, err := json.Marshal(req.User)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal user: %w", err)
+				return nil, stackWrap(err, "failed to marshal user")
 			}
 			err = writer.WriteField("user", string(userJSON))
 			if err != nil {
-				return nil, fmt.Errorf("failed to write user field: %w", err)
+				return nil, stackWrap(err, "failed to write user field")
 			}
 		}
 
@@ -323,17 +437,17 @@ func (c *Client) createMultipartRequest(r *http.Request, data any) (*http.Reques
 	// Add file field
 	fileWriter, err := writer.CreateFormFile("file", fileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create form file: %w", err)
+		return nil, stackWrap(err, "failed to create form file")
 	}
 
 	_, err = io.Copy(fileWriter, fileContent)
 	if err != nil {
-		return nil, fmt.Errorf("failed to copy file content: %w", err)
+		return nil, stackWrap(err, "failed to copy file content")
 	}
 
 	err = writer.Close()
 	if err != nil {
-		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+		return nil, stackWrap(err, "failed to close multipart writer")
 	}
 
 	// Update request body and content type
@@ -449,13 +563,17 @@ func MakeRequest[GRequest any, GResponse any](c *Client, ctx context.Context, me
 	start := time.Now()
 	resp, err := c.httpClient.Do(r)
 	if err != nil {
-		return nil, err
+		// §6.1 — no HTTP response received. Wrap as ErrTransport with the
+		// language-side errorType classification; preserve the cause chain.
+		return nil, wrapTransportError(err)
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read HTTP response: %w", err)
+		// Body-read failure occurs after headers but before the full body
+		// arrives — treat as transport per spec §6.1.
+		return nil, wrapTransportError(err)
 	}
 
 	duration := time.Since(start)

--- a/http.go
+++ b/http.go
@@ -45,21 +45,7 @@ func (c *Client) logResponse(resp *http.Response, body []byte, duration time.Dur
 //
 // Category is signaled by the sentinel embedded via Is: callers branch with
 // errors.Is(err, ErrApiResponse | ErrRateLimited | ErrTransport | ErrTaskFailed)
-// and extract fields with errors.As(err, &streamErr). See
-// Server-Side SDK Error Handling Spec §4.2 / §5 for the field schema.
-//
-// Per-field population by sentinel:
-//
-//   - ErrApiResponse:  StatusCode, Code, Message, ExceptionFields, Unrecoverable,
-//     RawResponseBody, MoreInfo, Details, RateLimit, Duration are set from the
-//     APIError envelope. RetryAfter is zero. ErrorType is "". Task is nil.
-//   - ErrRateLimited:  same as ErrApiResponse + RetryAfter parsed from the
-//     Retry-After header (RFC 7231 §7.1.3). errors.Is(err, ErrApiResponse) also
-//     returns true.
-//   - ErrTransport:    Message and ErrorType are set; underlying transport
-//     error is reachable via errors.Unwrap. All API-envelope fields are zero.
-//   - ErrTaskFailed:   Task is set with the failed task's ErrorResult fields.
-//     All API-envelope fields are zero.
+// and extract fields with errors.As(err, &streamErr).
 type StreamError struct {
 	Code            int               `json:"code"`
 	Message         string            `json:"message"`
@@ -74,7 +60,7 @@ type StreamError struct {
 	// the backend omitted the field.
 	Details json.RawMessage `json:"details,omitempty"`
 	// RawResponseBody is the unparsed response body. Always set on API-response
-	// errors (including the §6.3 unparseable-body case).
+	// errors (including the unparseable-body case).
 	RawResponseBody string `json:"-"`
 	// RetryAfter is the parsed Retry-After header on HTTP 429. Zero otherwise.
 	RetryAfter time.Duration `json:"-"`
@@ -101,7 +87,7 @@ func (e *StreamError) Error() string {
 }
 
 // Is reports whether target matches the StreamError's category sentinel.
-// ErrRateLimited additionally matches ErrApiResponse per spec §4.2.
+// ErrRateLimited additionally matches ErrApiResponse.
 func (e *StreamError) Is(target error) bool {
 	if e == nil || target == nil {
 		return false
@@ -141,8 +127,8 @@ type StreamResponse[T any] struct {
 }
 
 // parseResponse parses the HTTP response into the provided result.
-// On HTTP 4xx/5xx returns a *StreamError populated per Server-Side SDK
-// Error Handling Spec §5/§6.
+// On HTTP 4xx/5xx returns a *StreamError populated from the APIError
+// envelope, or a sentinel-message StreamError when the body cannot be parsed.
 func parseResponse[GResponse any](c *Client, resp *http.Response, body []byte, result *GResponse) (*StreamResponse[GResponse], error) {
 	statusCode := resp.StatusCode
 	c.logger.Debug("Status Code: %d", statusCode)
@@ -157,8 +143,9 @@ func parseResponse[GResponse any](c *Client, resp *http.Response, body []byte, r
 	return addRateLimitInfo(resp.Header, result)
 }
 
-// buildAPIError constructs a *StreamError for an HTTP 4xx/5xx response per
-// spec §6.2 (parsed APIError envelope) and §6.3 (unparseable body).
+// buildAPIError constructs a *StreamError for an HTTP 4xx/5xx response.
+// Returns *StreamError populated from the APIError envelope, or a
+// sentinel-message StreamError when the body cannot be parsed.
 func buildAPIError(resp *http.Response, body []byte) *StreamError {
 	apiErr := &StreamError{
 		StatusCode:      resp.StatusCode,
@@ -169,8 +156,6 @@ func buildAPIError(resp *http.Response, body []byte) *StreamError {
 
 	if len(body) > 0 {
 		if err := json.Unmarshal(body, apiErr); err != nil {
-			// §6.3 — HTTP response received but body unparseable. NOT a
-			// transport error (the HTTP layer succeeded).
 			apiErr.Code = 0
 			apiErr.Message = "failed to parse error response"
 			apiErr.ExceptionFields = map[string]string{}
@@ -183,9 +168,6 @@ func buildAPIError(resp *http.Response, body []byte) *StreamError {
 		apiErr.Message = "empty response body"
 	}
 
-	// json.Unmarshal overwrites StatusCode if the body carries the legacy
-	// uppercase "StatusCode" field, then leaves zero values for absent fields.
-	// Restore non-zero StatusCode and ExceptionFields from the response.
 	if apiErr.StatusCode == 0 {
 		apiErr.StatusCode = resp.StatusCode
 	}
@@ -563,16 +545,12 @@ func MakeRequest[GRequest any, GResponse any](c *Client, ctx context.Context, me
 	start := time.Now()
 	resp, err := c.httpClient.Do(r)
 	if err != nil {
-		// §6.1 — no HTTP response received. Wrap as ErrTransport with the
-		// language-side errorType classification; preserve the cause chain.
 		return nil, wrapTransportError(err)
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		// Body-read failure occurs after headers but before the full body
-		// arrives — treat as transport per spec §6.1.
 		return nil, wrapTransportError(err)
 	}
 

--- a/tasks.go
+++ b/tasks.go
@@ -6,8 +6,7 @@ import (
 	"time"
 )
 
-// Default polling parameters for WaitForTask, per Server-Side SDK Error
-// Handling Spec §8.
+// Default poll interval is 1s; default timeout is 60s.
 const (
 	defaultTaskPollInterval = 1 * time.Second
 	defaultTaskWaitTimeout  = 60 * time.Second
@@ -50,8 +49,7 @@ func WithWaitForTaskTimeout(d time.Duration) WaitForTaskOption {
 //     ErrTransport and ErrorType "timeout"; the original cause (a
 //     context.DeadlineExceeded or ctx.Err()) is reachable via errors.Unwrap.
 //
-// Behavior matches Server-Side SDK Error Handling Spec §8. Defaults:
-// pollInterval = 1s, timeout = 60s; override with WaitForTaskOption.
+// Defaults: pollInterval = 1s, timeout = 60s; override with WaitForTaskOption.
 func WaitForTask(ctx context.Context, client *Stream, taskID string, opts ...WaitForTaskOption) (*StreamResponse[GetTaskResponse], error) {
 	cfg := &waitForTaskConfig{
 		pollInterval: defaultTaskPollInterval,

--- a/tasks.go
+++ b/tasks.go
@@ -1,0 +1,137 @@
+package getstream
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Default polling parameters for WaitForTask, per Server-Side SDK Error
+// Handling Spec §8.
+const (
+	defaultTaskPollInterval = 1 * time.Second
+	defaultTaskWaitTimeout  = 60 * time.Second
+)
+
+// WaitForTaskOption configures WaitForTask.
+type WaitForTaskOption func(*waitForTaskConfig)
+
+type waitForTaskConfig struct {
+	pollInterval time.Duration
+	timeout      time.Duration
+}
+
+// WithWaitForTaskPollInterval sets how often the task-status endpoint is
+// polled. Default 1s. Values <= 0 are ignored.
+func WithWaitForTaskPollInterval(d time.Duration) WaitForTaskOption {
+	return func(c *waitForTaskConfig) {
+		if d > 0 {
+			c.pollInterval = d
+		}
+	}
+}
+
+// WithWaitForTaskTimeout sets the maximum wait before returning a timeout
+// error. Default 60s. Values <= 0 disable the timeout (waits until ctx ends
+// or terminal status is reached).
+func WithWaitForTaskTimeout(d time.Duration) WaitForTaskOption {
+	return func(c *waitForTaskConfig) {
+		c.timeout = d
+	}
+}
+
+// WaitForTask polls the task-status endpoint until the task reaches a
+// terminal state, the configured timeout elapses, or ctx is cancelled.
+//
+//   - On status "completed": returns the final StreamResponse.
+//   - On status "failed": returns a *StreamError with sentinel ErrTaskFailed
+//     and the populated Task field.
+//   - On timeout or ctx cancellation: returns a *StreamError with sentinel
+//     ErrTransport and ErrorType "timeout"; the original cause (a
+//     context.DeadlineExceeded or ctx.Err()) is reachable via errors.Unwrap.
+//
+// Behavior matches Server-Side SDK Error Handling Spec §8. Defaults:
+// pollInterval = 1s, timeout = 60s; override with WaitForTaskOption.
+func WaitForTask(ctx context.Context, client *Stream, taskID string, opts ...WaitForTaskOption) (*StreamResponse[GetTaskResponse], error) {
+	cfg := &waitForTaskConfig{
+		pollInterval: defaultTaskPollInterval,
+		timeout:      defaultTaskWaitTimeout,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	deadline := time.Time{}
+	if cfg.timeout > 0 {
+		deadline = time.Now().Add(cfg.timeout)
+	}
+
+	var lastResult *StreamResponse[GetTaskResponse]
+	for {
+		taskResult, err := client.GetTask(ctx, taskID, &GetTaskRequest{})
+		if err != nil {
+			return lastResult, err
+		}
+		lastResult = taskResult
+
+		switch taskResult.Data.Status {
+		case "completed":
+			return taskResult, nil
+		case "failed":
+			return lastResult, taskFailureError(taskID, taskResult.Data.Error)
+		}
+
+		// Honor deadline before sleeping.
+		if !deadline.IsZero() && !time.Now().Before(deadline) {
+			return lastResult, taskTimeoutError(taskID, context.DeadlineExceeded)
+		}
+
+		select {
+		case <-ctx.Done():
+			return lastResult, taskTimeoutError(taskID, ctx.Err())
+		case <-time.After(cfg.pollInterval):
+		}
+	}
+}
+
+// taskFailureError constructs the *StreamError surfaced when a task reaches
+// status "failed".
+func taskFailureError(taskID string, errRes *ErrorResult) *StreamError {
+	details := &TaskErrorDetails{TaskID: taskID}
+	if errRes != nil {
+		details.ErrorType = errRes.Type
+		details.Description = errRes.Description
+		if errRes.Stacktrace != nil {
+			details.StackTrace = *errRes.Stacktrace
+		}
+		if errRes.Version != nil {
+			details.Version = *errRes.Version
+		}
+	}
+
+	msg := "stream task failed"
+	if details.Description != "" {
+		msg = "stream task failed: " + details.Description
+	}
+
+	return &StreamError{
+		sentinel: ErrTaskFailed,
+		Message:  msg,
+		Task:     details,
+		cause:    stackWrap(errors.New(msg), "task failed"),
+	}
+}
+
+// taskTimeoutError constructs the *StreamError surfaced when WaitForTask
+// exhausts its deadline or ctx is cancelled.
+func taskTimeoutError(taskID string, cause error) *StreamError {
+	if cause == nil {
+		cause = context.DeadlineExceeded
+	}
+	return &StreamError{
+		sentinel:  ErrTransport,
+		ErrorType: ErrorTypeTimeout,
+		Message:   "stream wait for task timed out: " + taskID,
+		cause:     stackWrap(cause, "wait for task "+taskID),
+	}
+}

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -1,0 +1,315 @@
+package getstream_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/GetStream/getstream-go/v4"
+)
+
+// scriptedHTTPClient returns a queued sequence of HTTP responses. Each
+// invocation pops one entry from the queue; if the queue is exhausted the
+// final entry is reused (useful for "infinite polling" scenarios).
+type scriptedHTTPClient struct {
+	bodies []string
+	calls  int32
+}
+
+func (c *scriptedHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	n := atomic.AddInt32(&c.calls, 1) - 1
+	idx := int(n)
+	if idx >= len(c.bodies) {
+		idx = len(c.bodies) - 1
+	}
+	body := c.bodies[idx]
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{},
+		Request:    req,
+	}, nil
+}
+
+func newTaskClient(t *testing.T, bodies []string) (*Stream, *scriptedHTTPClient) {
+	t.Helper()
+	mock := &scriptedHTTPClient{bodies: bodies}
+	client, err := NewClient(
+		"key", "secret",
+		WithBaseUrl("https://api.example.invalid"),
+		WithAuthToken("Bearer t"),
+		WithHTTPClient(mock),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client, mock
+}
+
+func mustMarshal(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestWaitForTask_Completed(t *testing.T) {
+	t.Parallel()
+	completedBody := mustMarshal(t, map[string]any{
+		"task_id": "task-1",
+		"status":  "completed",
+		"result":  map[string]any{"count": 42},
+	})
+	client, mock := newTaskClient(t, []string{completedBody})
+
+	res, err := WaitForTask(
+		context.Background(), client, "task-1",
+		WithWaitForTaskPollInterval(10*time.Millisecond),
+		WithWaitForTaskTimeout(2*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if res == nil || res.Data.Status != "completed" {
+		t.Fatalf("expected completed status, got %+v", res)
+	}
+	if atomic.LoadInt32(&mock.calls) != 1 {
+		t.Errorf("expected 1 call, got %d", mock.calls)
+	}
+}
+
+func TestWaitForTask_PollsUntilTerminal(t *testing.T) {
+	t.Parallel()
+	runningBody := mustMarshal(t, map[string]any{
+		"task_id": "task-1",
+		"status":  "running",
+	})
+	completedBody := mustMarshal(t, map[string]any{
+		"task_id": "task-1",
+		"status":  "completed",
+	})
+	client, mock := newTaskClient(t, []string{runningBody, runningBody, completedBody})
+
+	res, err := WaitForTask(
+		context.Background(), client, "task-1",
+		WithWaitForTaskPollInterval(5*time.Millisecond),
+		WithWaitForTaskTimeout(2*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Data.Status != "completed" {
+		t.Fatalf("status = %q, want completed", res.Data.Status)
+	}
+	if mock.calls < 3 {
+		t.Errorf("expected at least 3 polls, got %d", mock.calls)
+	}
+}
+
+func TestWaitForTask_Failed_ReturnsErrTaskFailed(t *testing.T) {
+	t.Parallel()
+	failedBody := mustMarshal(t, map[string]any{
+		"task_id": "task-1",
+		"status":  "failed",
+		"error": map[string]any{
+			"type":        "ValidationError",
+			"description": "channel does not exist",
+			"stacktrace":  "...",
+			"version":     "v1",
+		},
+	})
+	client, _ := newTaskClient(t, []string{failedBody})
+
+	_, err := WaitForTask(
+		context.Background(), client, "task-1",
+		WithWaitForTaskPollInterval(5*time.Millisecond),
+		WithWaitForTaskTimeout(2*time.Second),
+	)
+	if err == nil {
+		t.Fatalf("expected error on failed task, got nil")
+	}
+	if !errors.Is(err, ErrTaskFailed) {
+		t.Errorf("errors.Is(err, ErrTaskFailed) = false; got %v", err)
+	}
+
+	var se *StreamError
+	if !errors.As(err, &se) {
+		t.Fatalf("errors.As(*StreamError) = false")
+	}
+	if se.Task == nil {
+		t.Fatalf("StreamError.Task is nil")
+	}
+	if se.Task.TaskID != "task-1" || se.Task.ErrorType != "ValidationError" ||
+		se.Task.Description != "channel does not exist" || se.Task.StackTrace != "..." ||
+		se.Task.Version != "v1" {
+		t.Errorf("Task fields mismatch: %+v", se.Task)
+	}
+}
+
+func TestWaitForTask_Timeout_ReturnsTransportErrorTimeout(t *testing.T) {
+	t.Parallel()
+	runningBody := mustMarshal(t, map[string]any{
+		"task_id": "task-1",
+		"status":  "running",
+	})
+	client, _ := newTaskClient(t, []string{runningBody})
+
+	_, err := WaitForTask(
+		context.Background(), client, "task-1",
+		WithWaitForTaskPollInterval(10*time.Millisecond),
+		WithWaitForTaskTimeout(40*time.Millisecond),
+	)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !errors.Is(err, ErrTransport) {
+		t.Errorf("errors.Is(err, ErrTransport) = false; got %v", err)
+	}
+
+	var se *StreamError
+	if !errors.As(err, &se) {
+		t.Fatalf("errors.As(*StreamError) = false")
+	}
+	if se.ErrorType != ErrorTypeTimeout {
+		t.Errorf("ErrorType = %q, want %q", se.ErrorType, ErrorTypeTimeout)
+	}
+	if !strings.Contains(se.Message, "task-1") {
+		t.Errorf("Message should reference task ID; got %q", se.Message)
+	}
+}
+
+func TestWaitForTask_ContextCancel(t *testing.T) {
+	t.Parallel()
+	runningBody := mustMarshal(t, map[string]any{
+		"task_id": "task-1",
+		"status":  "running",
+	})
+	client, _ := newTaskClient(t, []string{runningBody})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := WaitForTask(
+		ctx, client, "task-1",
+		WithWaitForTaskPollInterval(10*time.Millisecond),
+		WithWaitForTaskTimeout(5*time.Second),
+	)
+	if err == nil {
+		t.Fatalf("expected error from ctx cancel, got nil")
+	}
+	// ctx cancel propagates as either an ErrTransport timeout (if our wait
+	// loop fired first) or as the SDK transport-error wrap of the cancelled
+	// HTTP request. Either way, ErrTransport must match.
+	if !errors.Is(err, ErrTransport) {
+		t.Errorf("errors.Is(err, ErrTransport) = false; got %v", err)
+	}
+}
+
+func TestWaitForTask_PropagatesAPIError(t *testing.T) {
+	t.Parallel()
+	// Mock returns a 200 with the running body. We override one entry to
+	// simulate a 500 by using an httpClient that returns a non-2xx for the
+	// first call.
+	httpClient := &errorOnceClient{
+		failNext:    true,
+		successBody: mustMarshal(t, map[string]any{"task_id": "task-1", "status": "completed"}),
+	}
+	client, err := NewClient(
+		"k", "s",
+		WithBaseUrl("https://x.invalid"),
+		WithAuthToken("Bearer t"),
+		WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = WaitForTask(
+		context.Background(), client, "task-1",
+		WithWaitForTaskPollInterval(5*time.Millisecond),
+		WithWaitForTaskTimeout(2*time.Second),
+	)
+	if err == nil {
+		t.Fatalf("expected APIError to propagate, got nil")
+	}
+	if !errors.Is(err, ErrApiResponse) {
+		t.Errorf("errors.Is(err, ErrApiResponse) = false; got %v", err)
+	}
+}
+
+type errorOnceClient struct {
+	failNext    bool
+	successBody string
+	mu          sync.Mutex
+}
+
+func (c *errorOnceClient) Do(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	fail := c.failNext
+	c.failNext = false
+	c.mu.Unlock()
+	if fail {
+		body := `{"code":1,"message":"server error","StatusCode":500}`
+		return &http.Response{
+			StatusCode: 500,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{},
+			Request:    req,
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Body:       io.NopCloser(strings.NewReader(c.successBody)),
+		Header:     http.Header{},
+		Request:    req,
+	}, nil
+}
+
+func TestStreamError_TransportRoundTrip(t *testing.T) {
+	t.Parallel()
+	httpClient := &alwaysErrorClient{}
+	client, err := NewClient(
+		"k", "s",
+		WithBaseUrl("https://x.invalid"),
+		WithAuthToken("Bearer t"),
+		WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = client.GetTask(context.Background(), "task-1", &GetTaskRequest{})
+	if err == nil {
+		t.Fatalf("expected transport error, got nil")
+	}
+	if !errors.Is(err, ErrTransport) {
+		t.Fatalf("errors.Is(err, ErrTransport) = false; got %v", err)
+	}
+	var se *StreamError
+	if !errors.As(err, &se) {
+		t.Fatalf("errors.As(*StreamError) = false")
+	}
+	if se.ErrorType == "" {
+		t.Errorf("ErrorType empty; expected a classification")
+	}
+}
+
+type alwaysErrorClient struct{}
+
+func (alwaysErrorClient) Do(_ *http.Request) (*http.Response, error) {
+	return nil, errors.New("dial tcp 1.2.3.4:443: connection refused")
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -24,15 +24,7 @@ func (c *StubHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-// waitForTaskInTests is a test-only wrapper over the public WaitForTask that
-// raises the wait budget to ~5 minutes with a 5s poll cadence — sized to
-// outlast async-task retry cycles on the backend (e.g. rate-limited bulk
-// hard-deletes that retry every 10-15s for several minutes before clearing).
-//
-// Behavioral note: unlike the public WaitForTask, on status "failed" this
-// returns the response with a nil error so existing tests can inspect
-// taskStatus.Data.Status without altering their assertions. New tests should
-// use the public WaitForTask directly and branch on errors.Is(err, ErrTaskFailed).
+// Test helper; raised wait budget for hard-delete style tasks.
 func waitForTaskInTests(ctx context.Context, client *Stream, taskID string) (*StreamResponse[GetTaskResponse], error) {
 	res, err := WaitForTask(
 		ctx, client, taskID,

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,7 +3,7 @@ package getstream_test
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"math/rand"
 	"net/http"
@@ -24,43 +24,28 @@ func (c *StubHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-// WaitForTask polls the task until it reaches a terminal status
-// ("completed" or "failed") and returns the final observation.
+// waitForTaskInTests is a test-only wrapper over the public WaitForTask that
+// raises the wait budget to ~5 minutes with a 5s poll cadence — sized to
+// outlast async-task retry cycles on the backend (e.g. rate-limited bulk
+// hard-deletes that retry every 10-15s for several minutes before clearing).
 //
-// Polling cadence ramps from 1s to a 5s cap. The 60-attempt budget
-// (~5 minutes) is sized to outlast async-task retry cycles on the
-// backend (e.g. rate-limited bulk hard-deletes that retry every
-// 10–15s for several minutes before clearing).
-//
-// If the budget is exhausted before a terminal status is observed,
-// the last observation is returned alongside a timeout error so
-// the caller can log the in-flight status for debugging.
-func WaitForTask(ctx context.Context, client *Stream, taskID string) (*StreamResponse[GetTaskResponse], error) {
-	const maxAttempts = 60
-	var lastResult *StreamResponse[GetTaskResponse]
-	for i := 0; i < maxAttempts; i++ {
-		taskResult, err := client.GetTask(context.Background(), taskID, &GetTaskRequest{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to get task result: %w", err)
-		}
-		lastResult = taskResult
-		switch taskResult.Data.Status {
-		case "completed", "failed":
-			return taskResult, nil
-		}
-
-		interval := time.Duration(i+1) * time.Second
-		if interval > 5*time.Second {
-			interval = 5 * time.Second
-		}
-
-		select {
-		case <-ctx.Done():
-			return lastResult, fmt.Errorf("context expired waiting for task %s: %w", taskID, ctx.Err())
-		case <-time.After(interval):
-		}
+// Behavioral note: unlike the public WaitForTask, on status "failed" this
+// returns the response with a nil error so existing tests can inspect
+// taskStatus.Data.Status without altering their assertions. New tests should
+// use the public WaitForTask directly and branch on errors.Is(err, ErrTaskFailed).
+func waitForTaskInTests(ctx context.Context, client *Stream, taskID string) (*StreamResponse[GetTaskResponse], error) {
+	res, err := WaitForTask(
+		ctx, client, taskID,
+		WithWaitForTaskTimeout(5*time.Minute),
+		WithWaitForTaskPollInterval(5*time.Second),
+	)
+	var streamErr *StreamError
+	if err != nil && errors.As(err, &streamErr) && errors.Is(err, ErrTaskFailed) {
+		// Preserve legacy test behavior: surface the failed observation
+		// rather than the new ErrTaskFailed error.
+		return res, nil
 	}
-	return lastResult, fmt.Errorf("task %s did not reach terminal status after %d attempts", taskID, maxAttempts)
+	return res, err
 }
 
 // ResourceManager manages resource cleanup for tests.


### PR DESCRIPTION
## Summary

- Adds four sentinel error categories on `*StreamError`: `ErrApiResponse`, `ErrRateLimited`, `ErrTransport`, `ErrTaskFailed`. Branch on category with `errors.Is`; extract structured fields with `errors.As(err, &streamErr)`.
- Wraps transport-layer failures (connection reset / timeout / DNS / TLS) at the HTTP-client boundary into `*StreamError` with sentinel `ErrTransport` and an `ErrorType` enum. Cause chain preserved.
- Parses `Retry-After` (RFC 7231 §7.1.3 integer + HTTP-date) on HTTP 429.
- Adds public `WaitForTask(ctx, client, taskID, opts...)`; returns `*StreamError` with `ErrTaskFailed` on failed status, `ErrTransport` + `ErrorType="timeout"` on poll timeout.
- Adds an in-tree `stack.Wrap` helper (~85 lines, `runtime.Caller`, no external dependency); replaces all `fmt.Errorf("...: %w", err)` in user-facing paths.

No breaking changes to existing fields on `StreamError`.

## Test plan

- [x] `make test` and `make lint` clean locally
- [ ] CI green