### PR TITLE
ci: fix scheduled test credentials and bump action versions

### DIFF
--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -9,17 +9,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    environment: feeds-enabled-shard
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.19"
 
       - name: Run tests
         env:
-          STREAM_KEY: ${{ secrets.STREAM_CHAT_API_KEY }}
-          STREAM_SECRET: ${{ secrets.STREAM_CHAT_API_SECRET }}
+          STREAM_BASE_URL: ${{ vars.STREAM_BASE_URL }}
+          STREAM_API_KEY: ${{ vars.STREAM_API_KEY }}
+          STREAM_API_SECRET: ${{ secrets.STREAM_API_SECRET }}
         run: |
           # Retry 3 times because tests can be flaky
           for _ in 1 2 3;


### PR DESCRIPTION
## Problem

The weekly **Scheduled tests** job has been failing ([example run](https://github.com/GetStream/getstream-go/actions/runs/26750193474/job/78835898285)). Every integration test fails with `STREAM_API_KEY is empty`. This is not a flaky test or code bug; PR CI (`ci.yml`) is green. The scheduled workflow was never wired to the right credentials.

Three issues, all in `scheduled_test.yml`:

1. **Wrong env var names.** The client reads `STREAM_API_KEY` / `STREAM_API_SECRET` (`client.go:178-189`), but the job exported `STREAM_KEY` / `STREAM_SECRET`, which the code never reads.
2. **Wrong secret references.** It pointed at `secrets.STREAM_CHAT_API_KEY` / `secrets.STREAM_CHAT_API_SECRET`, which do not exist in this repo (logs show both blank). The real values are `vars.STREAM_API_KEY` and `secrets.STREAM_API_SECRET`.
3. **Missing environment.** Those vars/secrets are scoped to the `feeds-enabled-shard` environment, so they would not resolve even with correct names.

## Fix

Align the env block with `ci.yml`: add `environment: feeds-enabled-shard`, use the correct `vars`/`secrets` names, and add `STREAM_BASE_URL`. Also bump `actions/checkout@v3 → v4` and `actions/setup-go@v3 → v5` to clear the Node 20 deprecation warnings.

## Validation

Trigger manually via `workflow_dispatch` after merge (or from this branch) to confirm green before relying on the weekly schedule.

## Notes / follow-ups (not in this PR)

- The `Notify Slack if failed` step also errored with `not_authed` (`SLACK_NOTIFICATIONS_BOT_TOKEN` appears unset). Worth confirming that secret exists; it only fired because the test step failed.
- `voxmedia/github-action-slack-notify-build@v1` is also Node-20 deprecated, but it has no GitHub-owned successor; left as-is to avoid a blind third-party bump.
- This scheduled job now largely duplicates the integration suite that `ci.yml` already runs on every push/PR. Worth deciding whether it should stay or run a narrower set.