### PR TITLE
feat: add segment management methods to ChatClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
+* Added segment management methods to `ChatClient`: `CreateSegment`, `UpdateSegment`, and `AddSegmentTargets`. Segments targeted by a campaign can now be created and edited through the SDK, completing the campaign workflow without falling back to raw REST ([CHA-3483](https://linear.app/stream/issue/CHA-3483)).
 * Standardized error handling per the Server-Side SDK Error Handling Spec ([CHA-2958](https://linear.app/stream/issue/CHA-2958)).
   * Four sentinel error categories on the existing `*StreamError`: `ErrApiResponse`, `ErrRateLimited`, `ErrTransport`, `ErrTaskFailed`. Use `errors.Is(err, ...)` to branch and `errors.As(err, &streamErr)` to extract typed fields. `ErrRateLimited` also satisfies `errors.Is(err, ErrApiResponse)`.
   * New fields on `StreamError`: `Unrecoverable`, `Details`, `RawResponseBody`, `RetryAfter`, `ErrorType`, `Task`. No existing field accesses change.

--- a/chat.go
+++ b/chat.go
@@ -868,6 +868,13 @@ func (c *ChatClient) Search(ctx context.Context, request *SearchRequest) (*Strea
 	return res, err
 }
 
+// Create segment
+func (c *ChatClient) CreateSegment(ctx context.Context, request *CreateSegmentRequest) (*StreamResponse[CreateSegmentResponse], error) {
+	var result CreateSegmentResponse
+	res, err := MakeRequest[CreateSegmentRequest, CreateSegmentResponse](c.client, ctx, "POST", "/api/v2/chat/segments", nil, request, &result, nil)
+	return res, err
+}
+
 // Query segments
 func (c *ChatClient) QuerySegments(ctx context.Context, request *QuerySegmentsRequest) (*StreamResponse[QuerySegmentsResponse], error) {
 	var result QuerySegmentsResponse
@@ -892,6 +899,26 @@ func (c *ChatClient) GetSegment(ctx context.Context, id string, request *GetSegm
 		"id": id,
 	}
 	res, err := MakeRequest[any, GetSegmentResponse](c.client, ctx, "GET", "/api/v2/chat/segments/{id}", nil, nil, &result, pathParams)
+	return res, err
+}
+
+// Update an existing segment
+func (c *ChatClient) UpdateSegment(ctx context.Context, id string, request *UpdateSegmentRequest) (*StreamResponse[UpdateSegmentResponse], error) {
+	var result UpdateSegmentResponse
+	pathParams := map[string]string{
+		"id": id,
+	}
+	res, err := MakeRequest[UpdateSegmentRequest, UpdateSegmentResponse](c.client, ctx, "PUT", "/api/v2/chat/segments/{id}", nil, request, &result, pathParams)
+	return res, err
+}
+
+// Add targets to a segment
+func (c *ChatClient) AddSegmentTargets(ctx context.Context, id string, request *AddSegmentTargetsRequest) (*StreamResponse[Response], error) {
+	var result Response
+	pathParams := map[string]string{
+		"id": id,
+	}
+	res, err := MakeRequest[AddSegmentTargetsRequest, Response](c.client, ctx, "POST", "/api/v2/chat/segments/{id}/addtargets", nil, request, &result, pathParams)
 	return res, err
 }
 

--- a/chat_misc_integration_test.go
+++ b/chat_misc_integration_test.go
@@ -1927,6 +1927,11 @@ func TestChatSegmentCampaignIntegration(t *testing.T) {
 		SegmentIds:      []string{segmentID},
 		CreateChannels:  PtrTo(true),
 		MessageTemplate: CampaignMessageTemplate{Text: "hello from integration test"},
+		// channel_template is required by the backend when create_channels is true.
+		ChannelTemplate: &CampaignChannelTemplate{
+			Type: "messaging",
+			ID:   PtrTo("{{receiver.id}}-{{sender.id}}"),
+		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, campaignResp.Data.Campaign)
@@ -1936,7 +1941,13 @@ func TestChatSegmentCampaignIntegration(t *testing.T) {
 		_, _ = client.Chat().DeleteCampaign(context.Background(), campaignID, &DeleteCampaignRequest{})
 	})
 
-	_, err = client.Chat().StartCampaign(ctx, campaignID, &StartCampaignRequest{})
+	// Schedule for the future so the campaign stays in "scheduled" state, then
+	// stop it. A campaign started immediately could complete before the stop
+	// call lands, and a completed campaign cannot be stopped.
+	scheduledFor := time.Now().Add(time.Hour)
+	_, err = client.Chat().StartCampaign(ctx, campaignID, &StartCampaignRequest{
+		ScheduledFor: PtrTo(Timestamp{Time: &scheduledFor}),
+	})
 	require.NoError(t, err)
 
 	_, err = client.Chat().StopCampaign(ctx, campaignID, &StopCampaignRequest{})

--- a/chat_misc_integration_test.go
+++ b/chat_misc_integration_test.go
@@ -1875,3 +1875,70 @@ func TestChatContextExceededIntegration(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
+
+// TestChatSegmentCampaignIntegration exercises the full campaign flow that
+// requires the segment management endpoints: create a segment, add targets,
+// create a campaign that targets it, then start and stop it. Skips when the
+// app does not have the campaigns feature enabled.
+func TestChatSegmentCampaignIntegration(t *testing.T) {
+	t.Parallel()
+	skipIfShort(t)
+	client := initClient(t)
+	ctx := context.Background()
+
+	userIDs := createTestUsers(t, client, 2)
+	senderID, targetID := userIDs[0], userIDs[1]
+
+	segmentID := "test-segment-" + randomString(12)
+	createResp, err := client.Chat().CreateSegment(ctx, &CreateSegmentRequest{
+		Type: "user",
+		ID:   PtrTo(segmentID),
+		Name: PtrTo("integration test segment"),
+	})
+	if err != nil && (strings.Contains(err.Error(), "not enabled") || strings.Contains(err.Error(), "not available")) {
+		t.Skip("Campaigns feature not enabled for this app")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, createResp.Data.Segment)
+	require.Equal(t, segmentID, createResp.Data.Segment.ID)
+
+	t.Cleanup(func() {
+		_, _ = client.Chat().DeleteSegment(context.Background(), segmentID, &DeleteSegmentRequest{})
+	})
+
+	// Add the target user, then confirm it is in the segment.
+	_, err = client.Chat().AddSegmentTargets(ctx, segmentID, &AddSegmentTargetsRequest{
+		TargetIds: []string{targetID},
+	})
+	require.NoError(t, err)
+
+	_, err = client.Chat().SegmentTargetExists(ctx, segmentID, targetID, &SegmentTargetExistsRequest{})
+	require.NoError(t, err)
+
+	// Update the segment description through the newly exposed endpoint.
+	_, err = client.Chat().UpdateSegment(ctx, segmentID, &UpdateSegmentRequest{
+		Description: PtrTo("updated by integration test"),
+	})
+	require.NoError(t, err)
+
+	// Create a campaign targeting the segment, then start and stop it.
+	campaignResp, err := client.Chat().CreateCampaign(ctx, &CreateCampaignRequest{
+		SenderID:        senderID,
+		SegmentIds:      []string{segmentID},
+		CreateChannels:  PtrTo(true),
+		MessageTemplate: CampaignMessageTemplate{Text: "hello from integration test"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, campaignResp.Data.Campaign)
+	campaignID := campaignResp.Data.Campaign.ID
+
+	t.Cleanup(func() {
+		_, _ = client.Chat().DeleteCampaign(context.Background(), campaignID, &DeleteCampaignRequest{})
+	})
+
+	_, err = client.Chat().StartCampaign(ctx, campaignID, &StartCampaignRequest{})
+	require.NoError(t, err)
+
+	_, err = client.Chat().StopCampaign(ctx, campaignID, &StopCampaignRequest{})
+	require.NoError(t, err)
+}

--- a/chat_test.go
+++ b/chat_test.go
@@ -534,6 +534,13 @@ func TestChatSearch(t *testing.T) {
 	_, err = client.Chat().Search(context.Background(), &getstream.SearchRequest{})
 	require.NoError(t, err)
 }
+func TestChatCreateSegment(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Chat().CreateSegment(context.Background(), &getstream.CreateSegmentRequest{})
+	require.NoError(t, err)
+}
 func TestChatQuerySegments(t *testing.T) {
 	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
 	require.NoError(t, err)
@@ -553,6 +560,20 @@ func TestChatGetSegment(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.Chat().GetSegment(context.Background(), "", &getstream.GetSegmentRequest{})
+	require.NoError(t, err)
+}
+func TestChatUpdateSegment(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Chat().UpdateSegment(context.Background(), "", &getstream.UpdateSegmentRequest{})
+	require.NoError(t, err)
+}
+func TestChatAddSegmentTargets(t *testing.T) {
+	client, err := getstream.NewClient("key", "secret", getstream.WithHTTPClient(&StubHTTPClient{}))
+	require.NoError(t, err)
+
+	_, err = client.Chat().AddSegmentTargets(context.Background(), "", &getstream.AddSegmentTargetsRequest{})
 	require.NoError(t, err)
 }
 func TestChatDeleteSegmentTargets(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -6235,6 +6235,18 @@ type GetReviewQueueItemResponse struct {
 	Item     *ReviewQueueItemResponse `json:"item,omitempty"`
 }
 
+type CreateSegmentResponse struct {
+	// Duration of the request in milliseconds
+	Duration string           `json:"duration"`
+	Segment  *SegmentResponse `json:"segment,omitempty"`
+}
+
+type UpdateSegmentResponse struct {
+	// Duration of the request in milliseconds
+	Duration string          `json:"duration"`
+	Segment  SegmentResponse `json:"segment"`
+}
+
 type GetSegmentResponse struct {
 	// Duration of the request in milliseconds
 	Duration string           `json:"duration"`

--- a/requests.go
+++ b/requests.go
@@ -690,11 +690,39 @@ type QuerySegmentsRequest struct {
 	// Array of sort parameters
 	Sort []SortParamRequest `json:"sort"`
 }
+type CreateSegmentRequest struct {
+	// The type of the segment
+	Type string `json:"type"`
+	// If true, all sender channels are included in the segment
+	AllSenderChannels *bool `json:"all_sender_channels,omitempty"`
+	// If true, all users are included in the segment
+	AllUsers *bool `json:"all_users,omitempty"`
+	// The description of the segment
+	Description *string `json:"description,omitempty"`
+	// The ID of the segment
+	ID *string `json:"id,omitempty"`
+	// The name of the segment
+	Name *string `json:"name,omitempty"`
+	// Filter to apply to the query
+	Filter map[string]any `json:"filter"`
+}
+type UpdateSegmentRequest struct {
+	// Description
+	Description *string `json:"description,omitempty"`
+	// Name
+	Name *string `json:"name,omitempty"`
+	// Filter to apply to the query
+	Filter map[string]any `json:"filter"`
+}
 type DeleteSegmentRequest struct {
 }
 type GetSegmentRequest struct {
 }
 type DeleteSegmentTargetsRequest struct {
+	// Target IDs
+	TargetIds []string `json:"target_ids"`
+}
+type AddSegmentTargetsRequest struct {
 	// Target IDs
 	TargetIds []string `json:"target_ids"`
 }

--- a/requests.go
+++ b/requests.go
@@ -697,19 +697,19 @@ type CreateSegmentRequest struct {
 	AllSenderChannels *bool `json:"all_sender_channels,omitempty"`
 	// If true, all users are included in the segment
 	AllUsers *bool `json:"all_users,omitempty"`
-	// The description of the segment
+	// The description of the segment (max 256 characters)
 	Description *string `json:"description,omitempty"`
 	// The ID of the segment
 	ID *string `json:"id,omitempty"`
-	// The name of the segment
+	// The name of the segment (max 128 characters)
 	Name *string `json:"name,omitempty"`
 	// Filter to apply to the query
 	Filter map[string]any `json:"filter"`
 }
 type UpdateSegmentRequest struct {
-	// Description
+	// The description of the segment (max 256 characters)
 	Description *string `json:"description,omitempty"`
-	// Name
+	// The name of the segment (max 128 characters)
 	Name *string `json:"name,omitempty"`
 	// Filter to apply to the query
 	Filter map[string]any `json:"filter"`


### PR DESCRIPTION
## Summary
Adds the segment management methods to `ChatClient`: `CreateSegment`, `UpdateSegment`, `AddSegmentTargets`. These are the endpoints needed to build and edit the segment a campaign targets. The campaign methods were already present, but without segment create/update/add-targets the workflow could not be completed through the SDK and customers fell back to raw REST (reported by rewardstyle).

Depends on GetStream/chat#14006, which exposes the three endpoints in the OpenAPI spec (they were `Ignore: true`). The methods and types here match what regenerating from that spec produces; applied surgically to avoid unrelated regen drift.

## Changes
- `chat.go`: `CreateSegment`, `UpdateSegment`, `AddSegmentTargets`
- `requests.go`: `CreateSegmentRequest`, `UpdateSegmentRequest`, `AddSegmentTargetsRequest`
- `models.go`: `CreateSegmentResponse`, `UpdateSegmentResponse`
- `chat_test.go`: stub smoke tests for the three methods
- `chat_misc_integration_test.go`: `TestChatSegmentCampaignIntegration` covering create segment, add targets, update, then create/start/stop a campaign (skips when the app lacks the campaigns feature)
- `CHANGELOG.md`: 4.2.0 entry

## Testing
- `go test -short -race ./...` passes
- `go vet ./...` clean, `gofumpt` clean

## Note
Hold merge until GetStream/chat#14006 lands and the campaigns owner confirms the payloads are intended-public.
