### PR TITLE
Enhance timestamp parsing to support JSON strings

### DIFF
--- a/rfc3339.go
+++ b/rfc3339.go
@@ -21,12 +21,21 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 	if strData == "null" {
 		return nil
 	}
-
+	// NEW: Try to parse as a JSON string (RFC3339 / ISO8601) first.
+	// JSON strings are wrapped in double quotes.
+	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
+		var parsed time.Time
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			return fmt.Errorf("failed to parse timestamp string: %w", err)
+		}
+		t.Time = &parsed
+		return nil
+	}
+	// FALLBACK: Parse as Unix nanoseconds (integer) as it did originally
 	ns, err := strconv.ParseInt(strData, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse timestamp: %w", err)
 	}
-
 	utcT := time.Unix(0, ns).UTC()
 	t.Time = &utcT
 	return nil


### PR DESCRIPTION
Added functionality to parse JSON timestamp strings in RFC3339 format before falling back to Unix nanoseconds.

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Fixes: https://github.com/GetStream/getstream-go/issues/26
