### PR TITLE
feat: emit structured log events and redact secrets from debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Stream is free for most side and hobby projects. To qualify, your project/compan
 
 This repo contains the Golang server-side SDK developed by the team and Stream community. For a feature overview please visit our [roadmap](https://github.com/GetStream/protocol/discussions/177).
 
+## 🪵 Logging
+
+The client accepts a custom logger via `WithLogger` (any type implementing the `Logger` interface: `Debug`/`Info`/`Warn`/`Error`). Without one, it falls back to a stderr logger at INFO level, so per-request DEBUG events are silent by default; inject a logger with DEBUG enabled to see them.
+
+Four structured events are emitted: `client.initialized` (INFO, once at construction, with SDK name/version and connection-pool settings), `http.request.sent` (DEBUG, before each request), `http.response.received` (DEBUG, after any response including 4xx/5xx, status codes are just data on this event), and `http.request.failed` (ERROR, transport-layer failures only, e.g. connection reset, timeout, DNS, TLS, when no HTTP response was received at all).
+
+**Security:** these events never log HTTP headers (so `Authorization` is never written to logs), and known-secret values are always redacted regardless of logger: query parameters `api_key`, `api_secret`, and `token` become `<redacted>`, and top-level JSON body keys `api_secret`, `token`, and `password` become `<redacted>`. Request/response bodies are not logged by default. Opt in with `WithLogBodies(true)` if you need them for debugging, this logs a one-time WARN on construction because other sensitive data (message content, PII) may still appear in bodies even with the known-secret keys redacted.
+
 ## ✍️ Contributing
 
 We welcome code changes that improve this library or fix a problem, please make sure to follow all best practices and add tests if applicable before submitting a Pull Request on Github. We are very happy to merge your code in the official repository. Make sure to sign our [Contributor License Agreement (CLA)](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) first. See our [license file](./LICENSE) for more details.

--- a/client.go
+++ b/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	httpClient         HttpClient
 	httpClientFromUser bool // true iff WithHTTPClient was used; gates transport build
 	logger             Logger
+	logBodies          bool // true iff WithLogBodies(true) was used; gates body fields on DEBUG events
 }
 
 func (c *Client) HttpClient() HttpClient {
@@ -145,6 +146,14 @@ func WithBaseUrl(baseURL string) ClientOption {
 func WithLogger(logger Logger) ClientOption {
 	return func(c *Client) {
 		c.logger = logger
+	}
+}
+
+// WithLogBodies opts in to logging request/response bodies on the DEBUG
+// events. Known-secret body keys are still redacted. Off by default.
+func WithLogBodies(enabled bool) ClientOption {
+	return func(c *Client) {
+		c.logBodies = enabled
 	}
 }
 
@@ -270,16 +279,12 @@ func newClient(apiKey, apiSecret string, options ...ClientOption) (*Client, erro
 		client.authToken = token
 	}
 
-	if client.httpClientFromUser {
-		client.logger.Info("connection pool: user_http_client=true (5 knobs not applied)")
-	} else {
-		client.logger.Info(
-			"connection pool: max_conns_per_host=%d idle_timeout=%s connect_timeout=%s request_timeout=%s user_http_client=false",
-			client.maxConnsPerHost,
-			client.idleTimeout,
-			client.connectTimeout,
-			client.defaultTimeout,
-		)
+	client.logger.Info(
+		"client.initialized stream.sdk.name=getstream-go stream.sdk.version=%s stream.client.max_conns_per_host=%d stream.client.idle_timeout_seconds=%d stream.client.connect_timeout_seconds=%d stream.client.request_timeout_seconds=%d stream.client.gzip_enabled=%t stream.client.user_http_client=%t stream.client.log_bodies=%t",
+		versionName, client.maxConnsPerHost, int(client.idleTimeout.Seconds()), int(client.connectTimeout.Seconds()), int(client.defaultTimeout.Seconds()), true, client.httpClientFromUser, client.logBodies,
+	)
+	if client.logBodies {
+		client.logger.Warn("HTTP request/response bodies will be logged. Auth headers and known-secret fields are still redacted, but other sensitive data (messages, PII) may appear in logs. Disable for production.")
 	}
 
 	return client, nil

--- a/client_test.go
+++ b/client_test.go
@@ -255,11 +255,13 @@ func TestClientInfoLogOnConstruction(t *testing.T) {
 
 	require.Len(t, cap.infos, 1, "exactly one INFO line on construction")
 	got := cap.infos[0]
-	assert.Contains(t, got, "max_conns_per_host=5")
-	assert.Contains(t, got, "idle_timeout=55s")
-	assert.Contains(t, got, "connect_timeout=10s")
-	assert.Contains(t, got, "request_timeout=30s")
-	assert.Contains(t, got, "user_http_client=false")
+	assert.Contains(t, got, "client.initialized")
+	assert.Contains(t, got, "stream.sdk.name=getstream-go")
+	assert.Contains(t, got, "stream.client.max_conns_per_host=5")
+	assert.Contains(t, got, "stream.client.idle_timeout_seconds=55")
+	assert.Contains(t, got, "stream.client.connect_timeout_seconds=10")
+	assert.Contains(t, got, "stream.client.request_timeout_seconds=30")
+	assert.Contains(t, got, "stream.client.user_http_client=false")
 }
 
 func TestClientInfoLogWithUserHTTPClient(t *testing.T) {
@@ -272,7 +274,7 @@ func TestClientInfoLogWithUserHTTPClient(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, cap.infos, 1)
-	assert.Contains(t, cap.infos[0], "user_http_client=true")
+	assert.Contains(t, cap.infos[0], "stream.client.user_http_client=true")
 }
 
 func TestClientGetters(t *testing.T) {

--- a/http.go
+++ b/http.go
@@ -519,7 +519,10 @@ func MakeRequest[GRequest any, GResponse any](c *Client, ctx context.Context, me
 	if c.logBodies && data != nil && method != http.MethodGet && method != http.MethodHead {
 		reqBody, _ = json.Marshal(data)
 	}
-	c.logRequestSent(method, path, params, reqBody)
+	// r.URL.Query() is the actual built query (includes the api_key requestURL
+	// injects), not the caller's params — params alone would log an empty
+	// query for the ~246 of 316 call sites that pass nil.
+	c.logRequestSent(method, path, r.URL.Query(), reqBody)
 
 	start := time.Now()
 	resp, err := c.httpClient.Do(r)

--- a/http.go
+++ b/http.go
@@ -16,40 +16,6 @@ import (
 	"time"
 )
 
-// logRequest logs the details of an HTTP request
-func (c *Client) logRequest(req *http.Request) {
-	c.logger.Debug("---> %s %s", req.Method, req.URL.String())
-	c.logger.Debug("Host: %s", req.Host)
-	for key, values := range req.Header {
-		c.logger.Debug("%s: %s", key, strings.Join(values, ", "))
-	}
-	if req.Body == nil {
-		return
-	}
-	// Read via GetBody so the live body stays intact; only drain+restore when
-	// there's no GetBody (streaming bodies).
-	if req.GetBody != nil {
-		if rc, err := req.GetBody(); err == nil {
-			body, _ := io.ReadAll(rc)
-			rc.Close()
-			c.logger.Debug("\n%s", string(body))
-			return
-		}
-	}
-	body, _ := io.ReadAll(req.Body)
-	req.Body = io.NopCloser(bytes.NewReader(body))
-	c.logger.Debug("\n%s", string(body))
-}
-
-// logResponse logs the details of an HTTP response
-func (c *Client) logResponse(resp *http.Response, body []byte, duration time.Duration) {
-	c.logger.Debug("<--- %d %s (%s)", resp.StatusCode, http.StatusText(resp.StatusCode), duration)
-	for key, values := range resp.Header {
-		c.logger.Debug("%s: %s", key, strings.Join(values, ", "))
-	}
-	c.logger.Debug("\n%s", string(body))
-}
-
 // StreamError is the single concrete error type returned by the SDK.
 //
 // Category is signaled by the sentinel embedded via Is: callers branch with
@@ -140,7 +106,6 @@ type StreamResponse[T any] struct {
 // envelope, or a sentinel-message StreamError when the body cannot be parsed.
 func parseResponse[GResponse any](c *Client, resp *http.Response, body []byte, result *GResponse) (*StreamResponse[GResponse], error) {
 	statusCode := resp.StatusCode
-	c.logger.Debug("Status Code: %d", statusCode)
 	if statusCode >= 399 {
 		return nil, buildAPIError(resp, body)
 	}
@@ -208,11 +173,8 @@ func (c *Client) requestURL(path string, values url.Values, pathParams map[strin
 	}
 
 	values.Add("api_key", c.apiKey)
-	c.logger.Debug("Query parameters: %v", values)
 	u.RawQuery = values.Encode()
-	url := u.String()
-	c.logger.Debug("Full URL: %s", url)
-	return url, nil
+	return u.String(), nil
 }
 
 // buildPath constructs a URL path with parameters, escaping them appropriately.
@@ -251,34 +213,25 @@ func newRequest[T any](c *Client, ctx context.Context, method, path string, para
 	// Do not set body if the method is GET
 	if method == http.MethodGet {
 		r.Body = nil
-		c.logger.Debug("GET request: No body set")
 		return r, nil
 	}
 
-	// Handle other methods with body
-	c.logger.Debug("Method: %s, Data: %#v (Type: %T)", method, data, data)
-
 	switch t := any(data).(type) {
 	case nil:
-		c.logger.Debug("Data is nil")
 		r.Body = nil
 	case io.ReadCloser:
-		c.logger.Debug("Data is io.ReadCloser")
 		r.Body = t
 	case io.Reader:
-		c.logger.Debug("Data is io.Reader")
 		r.Body = io.NopCloser(t)
 	case *UploadFileRequest, *UploadImageRequest, *UploadChannelFileRequest, *UploadChannelImageRequest:
 		return c.createMultipartRequest(r, t)
 	default:
-		c.logger.Debug("Data is of type %T, attempting to marshal to JSON", t)
 		b, err := json.Marshal(data)
 		if err != nil {
 			c.logger.Error("Error marshaling data: %+v, setting body to nil", err)
 			r.Body = nil
 		} else {
 			setRetryableBody(r, b)
-			c.logger.Debug("Request body set with JSON: %s", string(b))
 		}
 	}
 
@@ -560,22 +513,30 @@ func MakeRequest[GRequest any, GResponse any](c *Client, ctx context.Context, me
 		return nil, err
 	}
 
-	c.logRequest(r)
+	// Only re-marshal on opt-in (WithLogBodies) so the default path does zero
+	// extra work. GET/HEAD never carry a body.
+	var reqBody []byte
+	if c.logBodies && data != nil && method != http.MethodGet && method != http.MethodHead {
+		reqBody, _ = json.Marshal(data)
+	}
+	c.logRequestSent(method, path, params, reqBody)
 
 	start := time.Now()
 	resp, err := c.httpClient.Do(r)
 	if err != nil {
+		c.logRequestFailed(method, path, err, time.Since(start))
 		return nil, wrapTransportError(err)
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
+		c.logRequestFailed(method, path, err, time.Since(start))
 		return nil, wrapTransportError(err)
 	}
 
 	duration := time.Since(start)
-	c.logResponse(resp, b, duration)
+	c.logResponseReceived(method, path, resp.StatusCode, len(b), duration, b)
 
 	return parseResponse(c, resp, b, response)
 }

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -131,17 +131,21 @@ func TestNewRequest_StreamingReader_NoGetBody(t *testing.T) {
 	require.Equal(t, "raw", string(b))
 }
 
-// logRequest must not consume the live body or drop GetBody.
-func TestLogRequest_PreservesBodyAndGetBody(t *testing.T) {
-	client, _ := newClient("k", "s", WithBaseUrl("https://api.example.com"))
-	req, err := newRequest(client, context.Background(), http.MethodPost, "/v1/x", nil, &getBodyTestRequest{Foo: "bar"}, nil)
+// logRequestSent re-marshals the caller's data independently of req.Body, so
+// it must not consume the live body or drop GetBody.
+func TestLogRequestSent_PreservesBodyAndGetBody(t *testing.T) {
+	client, _ := newClient("k", "s", WithBaseUrl("https://api.example.com"), WithLogBodies(true))
+	data := &getBodyTestRequest{Foo: "bar"}
+	req, err := newRequest(client, context.Background(), http.MethodPost, "/v1/x", nil, data, nil)
 	require.NoError(t, err)
 
-	client.logRequest(req)
+	b, err := json.Marshal(data)
+	require.NoError(t, err)
+	client.logRequestSent(http.MethodPost, "/v1/x", nil, b)
 
 	body, err := io.ReadAll(req.Body)
 	require.NoError(t, err)
-	require.Equal(t, getBodyTestJSON, string(body), "logRequest must not consume the live body")
+	require.Equal(t, getBodyTestJSON, string(body), "logRequestSent must not consume the live body")
 
 	rc, err := req.GetBody()
 	require.NoError(t, err)

--- a/logging.go
+++ b/logging.go
@@ -2,7 +2,9 @@ package getstream
 
 import (
 	"encoding/json"
+	"errors"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -15,7 +17,7 @@ var redactedBodyKeys = []string{"api_secret", "token", "password"}
 func redactQuery(q url.Values) string {
 	clone := url.Values{}
 	for k, vs := range q {
-		if _, secret := redactedQueryParams[toLowerASCII(k)]; secret {
+		if _, secret := redactedQueryParams[strings.ToLower(k)]; secret {
 			clone[k] = []string{"<redacted>"}
 			continue
 		}
@@ -48,23 +50,16 @@ func redactJSONBody(b []byte) string {
 	return string(out)
 }
 
-func toLowerASCII(s string) string {
-	b := []byte(s)
-	for i := range b {
-		if b[i] >= 'A' && b[i] <= 'Z' {
-			b[i] += 'a' - 'A'
-		}
-	}
-	return string(b)
-}
-
-func (c *Client) logRequestSent(method, path string, params url.Values, body []byte) {
+// logRequestSent logs the outgoing request. query must be the built request's
+// actual query (e.g. r.URL.Query()), not the caller-supplied params — the
+// caller's params never carry the api_key that requestURL injects.
+func (c *Client) logRequestSent(method, path string, query url.Values, body []byte) {
 	if c.logBodies && body != nil {
 		c.logger.Debug("http.request.sent http.request.method=%s url.path=%s url.query=%s http.request.body=%s",
-			method, path, redactQuery(params), redactJSONBody(body))
+			method, path, redactQuery(query), redactJSONBody(body))
 		return
 	}
-	c.logger.Debug("http.request.sent http.request.method=%s url.path=%s url.query=%s", method, path, redactQuery(params))
+	c.logger.Debug("http.request.sent http.request.method=%s url.path=%s url.query=%s", method, path, redactQuery(query))
 }
 
 func (c *Client) logResponseReceived(method, path string, statusCode, bodySize int, d time.Duration, body []byte) {
@@ -77,7 +72,18 @@ func (c *Client) logResponseReceived(method, path string, statusCode, bodySize i
 		method, path, statusCode, bodySize, d.Milliseconds())
 }
 
+// logRequestFailed logs a transport-layer failure. Classification runs on the
+// original err (needed to see through *url.Error to the real cause), but the
+// logged message unwraps *url.Error to its underlying cause: url.Error.Error()
+// embeds the full request URL, including unredacted api_key/api_secret/token
+// query values, so logging it verbatim would leak secrets on every real
+// *http.Client transport failure.
 func (c *Client) logRequestFailed(method, path string, err error, d time.Duration) {
+	msg := err.Error()
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		msg = ue.Err.Error()
+	}
 	c.logger.Error("http.request.failed http.request.method=%s url.path=%s error.type=%s error.message=%q duration_ms=%d",
-		method, path, classifyTransportError(err), err.Error(), d.Milliseconds())
+		method, path, classifyTransportError(err), msg, d.Milliseconds())
 }

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,83 @@
+package getstream
+
+import (
+	"encoding/json"
+	"net/url"
+	"time"
+)
+
+var redactedQueryParams = map[string]struct{}{"api_key": {}, "api_secret": {}, "token": {}}
+
+var redactedBodyKeys = []string{"api_secret", "token", "password"}
+
+// redactQuery returns the encoded query string with known-secret param values
+// replaced by <redacted>. The original values are never mutated.
+func redactQuery(q url.Values) string {
+	clone := url.Values{}
+	for k, vs := range q {
+		if _, secret := redactedQueryParams[toLowerASCII(k)]; secret {
+			clone[k] = []string{"<redacted>"}
+			continue
+		}
+		clone[k] = vs
+	}
+	return clone.Encode()
+}
+
+// redactJSONBody shallow-redacts known-secret top-level keys of a JSON object
+// body. Non-JSON-object bodies pass through unchanged.
+func redactJSONBody(b []byte) string {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		return string(b)
+	}
+	changed := false
+	for _, k := range redactedBodyKeys {
+		if _, ok := m[k]; ok {
+			m[k] = json.RawMessage(`"<redacted>"`)
+			changed = true
+		}
+	}
+	if !changed {
+		return string(b)
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return string(b)
+	}
+	return string(out)
+}
+
+func toLowerASCII(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+func (c *Client) logRequestSent(method, path string, params url.Values, body []byte) {
+	if c.logBodies && body != nil {
+		c.logger.Debug("http.request.sent http.request.method=%s url.path=%s url.query=%s http.request.body=%s",
+			method, path, redactQuery(params), redactJSONBody(body))
+		return
+	}
+	c.logger.Debug("http.request.sent http.request.method=%s url.path=%s url.query=%s", method, path, redactQuery(params))
+}
+
+func (c *Client) logResponseReceived(method, path string, statusCode, bodySize int, d time.Duration, body []byte) {
+	if c.logBodies {
+		c.logger.Debug("http.response.received http.request.method=%s url.path=%s http.response.status_code=%d http.response.body.size=%d duration_ms=%d http.response.body=%s",
+			method, path, statusCode, bodySize, d.Milliseconds(), redactJSONBody(body))
+		return
+	}
+	c.logger.Debug("http.response.received http.request.method=%s url.path=%s http.response.status_code=%d http.response.body.size=%d duration_ms=%d",
+		method, path, statusCode, bodySize, d.Milliseconds())
+}
+
+func (c *Client) logRequestFailed(method, path string, err error, d time.Duration) {
+	c.logger.Error("http.request.failed http.request.method=%s url.path=%s error.type=%s error.message=%q duration_ms=%d",
+		method, path, classifyTransportError(err), err.Error(), d.Milliseconds())
+}

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,172 @@
+package getstream
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+type recordingLogger struct {
+	debug, info, warn, errs []string
+}
+
+func (l *recordingLogger) Debug(f string, v ...interface{}) {
+	l.debug = append(l.debug, fmt.Sprintf(f, v...))
+}
+func (l *recordingLogger) Info(f string, v ...interface{}) {
+	l.info = append(l.info, fmt.Sprintf(f, v...))
+}
+func (l *recordingLogger) Warn(f string, v ...interface{}) {
+	l.warn = append(l.warn, fmt.Sprintf(f, v...))
+}
+func (l *recordingLogger) Error(f string, v ...interface{}) {
+	l.errs = append(l.errs, fmt.Sprintf(f, v...))
+}
+
+type oneShotClient struct {
+	status int
+	body   string
+	err    error
+	calls  int
+}
+
+func (s *oneShotClient) Do(r *http.Request) (*http.Response, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	return &http.Response{StatusCode: s.status, Header: h, Body: io.NopCloser(strings.NewReader(s.body))}, nil
+}
+
+func loggedGET(t *testing.T, fake HttpClient, opts ...ClientOption) (*recordingLogger, error) {
+	t.Helper()
+	rec := &recordingLogger{}
+	c, err := NewClient("key", "secret", append([]ClientOption{WithHTTPClient(fake), WithLogger(rec)}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	_, err = MakeRequest[map[string]any, map[string]any](c.Client, context.Background(), http.MethodGet, "/api/v2/app", url.Values{"api_key": {"key"}}, nil, &out, nil)
+	return rec, err
+}
+
+func has(entries []string, substr string) bool {
+	for _, e := range entries {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestClientInitializedEmittedOnce(t *testing.T) {
+	rec, _ := loggedGET(t, &oneShotClient{status: 200, body: `{}`})
+	count := 0
+	for _, e := range rec.info {
+		if strings.Contains(e, "client.initialized") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want exactly 1 client.initialized, got %d in %v", count, rec.info)
+	}
+	if !has(rec.info, "stream.sdk.name=getstream-go") || !has(rec.info, "max_conns_per_host") {
+		t.Fatalf("client.initialized missing schema fields: %v", rec.info)
+	}
+}
+
+func TestRequestAndResponseEventsOnSuccess(t *testing.T) {
+	rec, err := loggedGET(t, &oneShotClient{status: 200, body: `{}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has(rec.debug, "http.request.sent") || !has(rec.debug, "http.response.received") {
+		t.Fatalf("missing request/response events: %v", rec.debug)
+	}
+	if !has(rec.debug, "http.response.status_code=200") {
+		t.Fatalf("missing status code: %v", rec.debug)
+	}
+}
+
+func TestErrorStatusFlowsThroughResponseReceived(t *testing.T) {
+	rec, err := loggedGET(t, &oneShotClient{status: 500, body: `{"code":1,"message":"boom"}`})
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if !has(rec.debug, "http.response.status_code=500") {
+		t.Fatalf("want 500 via http.response.received: %v", rec.debug)
+	}
+	if has(rec.errs, "http.request.failed") {
+		t.Fatalf("4xx/5xx must not emit http.request.failed: %v", rec.errs)
+	}
+}
+
+func TestTransportFailureEmitsRequestFailed(t *testing.T) {
+	rec, err := loggedGET(t, &oneShotClient{err: syscall.ECONNRESET})
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if !has(rec.errs, "http.request.failed") || !has(rec.errs, "error.type=connection_reset") {
+		t.Fatalf("want http.request.failed with error.type: %v", rec.errs)
+	}
+}
+
+func TestQueryRedaction(t *testing.T) {
+	rec, _ := loggedGET(t, &oneShotClient{status: 200, body: `{}`})
+	for _, e := range rec.debug {
+		if strings.Contains(e, "api_key=key") {
+			t.Fatalf("api_key leaked: %q", e)
+		}
+	}
+	if !has(rec.debug, "api_key=%3Credacted%3E") && !has(rec.debug, "api_key=<redacted>") {
+		t.Fatalf("want redacted api_key in url.query: %v", rec.debug)
+	}
+}
+
+func TestNoHeadersInDebugOutput(t *testing.T) {
+	rec, _ := loggedGET(t, &oneShotClient{status: 200, body: `{}`})
+	for _, e := range append(rec.debug, rec.info...) {
+		if strings.Contains(e, "Authorization") {
+			t.Fatalf("Authorization header leaked: %q", e)
+		}
+	}
+}
+
+func TestLogBodiesOptInAndWarn(t *testing.T) {
+	recOff, _ := loggedGET(t, &oneShotClient{status: 200, body: `{"secret":"x"}`})
+	if has(recOff.debug, "http.response.body=") {
+		t.Fatalf("bodies logged without opt-in: %v", recOff.debug)
+	}
+	recOn, _ := loggedGET(t, &oneShotClient{status: 200, body: `{"token":"tok","ok":true}`}, WithLogBodies(true))
+	if len(recOn.warn) != 1 || !strings.Contains(recOn.warn[0], "bodies will be logged") {
+		t.Fatalf("want exactly one body-logging WARN, got %v", recOn.warn)
+	}
+	if !has(recOn.debug, "http.response.body=") {
+		t.Fatalf("want body field with opt-in: %v", recOn.debug)
+	}
+	if has(recOn.debug, `"token":"tok"`) {
+		t.Fatalf("token body key leaked: %v", recOn.debug)
+	}
+}
+
+func TestRedactJSONBody(t *testing.T) {
+	out := redactJSONBody([]byte(`{"token":"t","password":"p","api_secret":"s","keep":"v"}`))
+	for _, leak := range []string{`"t"`, `"p"`, `"s"`} {
+		if strings.Contains(out, leak) {
+			t.Fatalf("leak %s in %s", leak, out)
+		}
+	}
+	if !strings.Contains(out, `"keep":"v"`) {
+		t.Fatalf("non-secret key dropped: %s", out)
+	}
+	if got := redactJSONBody([]byte(`not json`)); got != "not json" {
+		t.Fatalf("non-JSON body must pass through, got %q", got)
+	}
+}

--- a/logging_test.go
+++ b/logging_test.go
@@ -159,6 +159,66 @@ func TestLogBodiesOptInAndWarn(t *testing.T) {
 	}
 }
 
+// Real *http.Client transport failures wrap the underlying cause in
+// *url.Error, whose Error() string embeds the full outgoing URL (including
+// api_key/api_secret/token query values). http.request.failed must not let
+// that URL reach error.message.
+func TestRequestFailedRedactsURLErrorMessage(t *testing.T) {
+	leaked := &url.Error{
+		Op:  "Get",
+		URL: "https://chat.stream-io-api.com/api/v2/app?api_key=SUPERSECRETKEY",
+		Err: syscall.ECONNRESET,
+	}
+	rec, err := loggedGET(t, &oneShotClient{err: leaked})
+	if err == nil {
+		t.Fatal("want error")
+	}
+	for _, e := range rec.errs {
+		if strings.Contains(e, "SUPERSECRETKEY") {
+			t.Fatalf("api_key leaked into error log: %q", e)
+		}
+	}
+	var line string
+	for _, e := range rec.errs {
+		if strings.Contains(e, "http.request.failed") {
+			line = e
+		}
+	}
+	if line == "" {
+		t.Fatalf("want http.request.failed event: %v", rec.errs)
+	}
+	if !strings.Contains(line, "error.type=") {
+		t.Fatalf("want error.type field: %q", line)
+	}
+	if strings.Contains(line, `error.message=""`) {
+		t.Fatalf("want non-empty error.message: %q", line)
+	}
+}
+
+// http.request.sent must log the actual built request query (with api_key
+// redacted) even when the caller passes nil params — requestURL injects
+// api_key into its own local copy, so only the built request carries it.
+func TestQuerySentReflectsBuiltRequestForNilParams(t *testing.T) {
+	rec := &recordingLogger{}
+	c, err := NewClient("realkey", "secret", WithHTTPClient(&oneShotClient{status: 200, body: `{}`}), WithLogger(rec))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	_, err = MakeRequest[map[string]any, map[string]any](c.Client, context.Background(), http.MethodGet, "/api/v2/app", nil, nil, &out, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has(rec.debug, "api_key=%3Credacted%3E") && !has(rec.debug, "api_key=<redacted>") {
+		t.Fatalf("want redacted api_key in url.query for nil params: %v", rec.debug)
+	}
+	for _, e := range rec.debug {
+		if strings.Contains(e, "realkey") {
+			t.Fatalf("raw api_key leaked with nil params: %q", e)
+		}
+	}
+}
+
 func TestRedactJSONBody(t *testing.T) {
 	out := redactJSONBody([]byte(`{"token":"t","password":"p","api_secret":"s","keep":"v"}`))
 	for _, leak := range []string{`"t"`, `"p"`, `"s"`} {

--- a/logging_test.go
+++ b/logging_test.go
@@ -18,12 +18,15 @@ type recordingLogger struct {
 func (l *recordingLogger) Debug(f string, v ...interface{}) {
 	l.debug = append(l.debug, fmt.Sprintf(f, v...))
 }
+
 func (l *recordingLogger) Info(f string, v ...interface{}) {
 	l.info = append(l.info, fmt.Sprintf(f, v...))
 }
+
 func (l *recordingLogger) Warn(f string, v ...interface{}) {
 	l.warn = append(l.warn, fmt.Sprintf(f, v...))
 }
+
 func (l *recordingLogger) Error(f string, v ...interface{}) {
 	l.errs = append(l.errs, fmt.Sprintf(f, v...))
 }


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-2957/logging

## Summary
Adds structured logging via the existing `Logger` interface: emits `client.initialized`, `http.request.sent`, `http.response.received`, and `http.request.failed` events with the standard field schema. Mandatory redaction of `api_key`/`api_secret`/`token` query values and `api_secret`/`token`/`password` body keys. Opt-in `WithLogBodies` adds (still-redacted) bodies with a one-shot WARN. No-logger behavior unchanged.

## Security
`Authorization` headers and secret query values are no longer logged (they were previously dumped verbatim at DEBUG). The `http.request.failed` message is scrubbed of any URL-embedded secret.

## Tests
Full `-short` unit suite green; new `logging_test.go` covers events, redaction, the no-header guarantee, and the transport-error message scrub.
