### PR TITLE
fix: align go module path with the v5 major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ All notable changes to this project will be documented in this file. See [standa
 - `Event` (WebSocket envelope type) renamed to `WSEvent`. Base event type renamed from `BaseEvent` to `Event` (with field `type` instead of `T`).
 - Event composition changed from monolithic `*Preset` embeds to modular `Has*` types (`HasChannel`, `HasMessage`, `HasUserCommonFields`, etc.).
 - `Pager` renamed to `PagerResponse` and migrated from offset-based to cursor-based pagination (`next`/`prev` tokens).
-- Module path changed from `github.com/GetStream/getstream-go/v4` to `github.com/GetStream/getstream-go/v4`.
+- Module path changed from `github.com/GetStream/getstream-go/v5` to `github.com/GetStream/getstream-go/v5`.
 
 ### Added
 

--- a/chat_channel_integration_test.go
+++ b/chat_channel_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chat_message_integration_test.go
+++ b/chat_message_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chat_misc_integration_test.go
+++ b/chat_misc_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chat_polls_integration_test.go
+++ b/chat_polls_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chat_reaction_integration_test.go
+++ b/chat_reaction_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chat_retention_integration_test.go
+++ b/chat_retention_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chat_test.go
+++ b/chat_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/require"
 )
 

--- a/chat_test_helpers_test.go
+++ b/chat_test_helpers_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )

--- a/chat_user_group_integration_test.go
+++ b/chat_user_group_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/chat_user_integration_test.go
+++ b/chat_user_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/chat_webhook_test.go
+++ b/chat_webhook_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/common_test.go
+++ b/common_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/require"
 )
 

--- a/docs/migration-from-stream-chat-go/01-setup-and-auth.md
+++ b/docs/migration-from-stream-chat-go/01-setup-and-auth.md
@@ -1,6 +1,6 @@
 # Setup and Authentication
 
-This guide shows how to migrate setup and authentication code from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+This guide shows how to migrate setup and authentication code from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v5`.
 
 ## Installation
 
@@ -13,11 +13,11 @@ go get github.com/GetStream/stream-chat-go/v8
 **After (getstream-go):**
 
 ```bash
-go get github.com/GetStream/getstream-go/v4
+go get github.com/GetStream/getstream-go/v5
 ```
 
 **Key changes:**
-- Module path changed from `stream-chat-go/v8` to `getstream-go/v4`
+- Module path changed from `stream-chat-go/v8` to `getstream-go/v5`
 
 ## Client Initialization
 
@@ -52,7 +52,7 @@ package main
 import (
 	"time"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -94,7 +94,7 @@ func main() {
 package main
 
 import (
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -136,7 +136,7 @@ package main
 import (
 	"time"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {

--- a/docs/migration-from-stream-chat-go/02-users.md
+++ b/docs/migration-from-stream-chat-go/02-users.md
@@ -1,6 +1,6 @@
 # Users
 
-This guide shows how to migrate user operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+This guide shows how to migrate user operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v5`.
 
 ## Upsert a Single User
 
@@ -40,7 +40,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -103,7 +103,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -162,7 +162,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -225,7 +225,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -283,7 +283,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -331,7 +331,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {

--- a/docs/migration-from-stream-chat-go/03-channels.md
+++ b/docs/migration-from-stream-chat-go/03-channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-This guide shows how to migrate channel operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+This guide shows how to migrate channel operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v5`.
 
 ## Create a Channel
 
@@ -35,7 +35,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -94,7 +94,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -154,7 +154,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -209,7 +209,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -269,7 +269,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -328,7 +328,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -378,7 +378,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -430,7 +430,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -483,7 +483,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {

--- a/docs/migration-from-stream-chat-go/04-messages-and-reactions.md
+++ b/docs/migration-from-stream-chat-go/04-messages-and-reactions.md
@@ -1,6 +1,6 @@
 # Messages and Reactions
 
-This guide shows how to migrate message and reaction operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+This guide shows how to migrate message and reaction operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v5`.
 
 ## Send a Message
 
@@ -35,7 +35,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -92,7 +92,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -143,7 +143,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -190,7 +190,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -248,7 +248,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -305,7 +305,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -358,7 +358,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -413,7 +413,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -461,7 +461,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {

--- a/docs/migration-from-stream-chat-go/05-moderation.md
+++ b/docs/migration-from-stream-chat-go/05-moderation.md
@@ -1,6 +1,6 @@
 # Moderation
 
-This guide shows how to migrate moderation operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+This guide shows how to migrate moderation operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v5`.
 
 ## Add Moderators
 
@@ -32,7 +32,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -81,7 +81,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -133,7 +133,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -187,7 +187,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -245,7 +245,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -309,7 +309,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -361,7 +361,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -411,7 +411,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {

--- a/docs/migration-from-stream-chat-go/06-devices.md
+++ b/docs/migration-from-stream-chat-go/06-devices.md
@@ -1,6 +1,6 @@
 # Devices
 
-This guide shows how to migrate device (push notification) operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v4`.
+This guide shows how to migrate device (push notification) operations from `github.com/GetStream/stream-chat-go/v8` to `github.com/GetStream/getstream-go/v5`.
 
 ## Add a Device
 
@@ -35,7 +35,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -89,7 +89,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -137,7 +137,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {
@@ -185,7 +185,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {

--- a/docs/migration-from-stream-chat-go/README.md
+++ b/docs/migration-from-stream-chat-go/README.md
@@ -11,7 +11,7 @@
 
 | Aspect | stream-chat-go | getstream-go |
 |--------|----------------|--------------|
-| Import | `github.com/GetStream/stream-chat-go/v8` | `github.com/GetStream/getstream-go/v4` |
+| Import | `github.com/GetStream/stream-chat-go/v8` | `github.com/GetStream/getstream-go/v5` |
 | Env vars | `STREAM_KEY`, `STREAM_SECRET` | `STREAM_API_KEY`, `STREAM_API_SECRET` |
 | Client init | `stream.NewClient(key, secret)` | `getstream.NewClient(key, secret)` |
 | Sub-clients | All methods on root client | `client.Chat()`, `client.Moderation()`, `client.Video()` |
@@ -52,7 +52,7 @@ package main
 import (
 	"context"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func main() {

--- a/examples_test.go
+++ b/examples_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/feeds_integration_test.go
+++ b/feeds_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/require"
 )
 

--- a/feedtest/example.go
+++ b/feedtest/example.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math/rand"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 )
 
 func getRandomString(length int) string {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GetStream/getstream-go/v4
+module github.com/GetStream/getstream-go/v5
 
 go 1.19
 

--- a/moderation_integration_test.go
+++ b/moderation_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/require"
 )
 

--- a/rate_limits_test.go
+++ b/rate_limits_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 )
 
 // scriptedHTTPClient returns a queued sequence of HTTP responses. Each

--- a/utils_test.go
+++ b/utils_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/GetStream/getstream-go/v4"
+	. "github.com/GetStream/getstream-go/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )

--- a/video_example_test.go
+++ b/video_example_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )

--- a/video_test.go
+++ b/video_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/GetStream/getstream-go/v4"
+	"github.com/GetStream/getstream-go/v5"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
The module is tagged **v5.0.0** but `go.mod` still declares `.../getstream-go/v4`. Per Go module semantics a v5+ tag requires the `/v5` suffix in the module path, so today `go get github.com/GetStream/getstream-go/v5` fails and the `/v4` path is invalid at a v5 tag.

This updates the module path to `/v5` in `go.mod` and every import site (test files, `feedtest`, and the `stream-chat-go` migration docs). The historical `MIGRATION_v3_to_v4.md` is intentionally left unchanged. Verified the module compiles with `go test -run '^NONE$' ./...`.

Merge this before cutting **v5.1.0** so the release is installable as `/v5`.