### PR TITLE
docs: align message partial-update migration example before/after

### DIFF
--- a/docs/migration-from-stream-chat-go/04-messages-and-reactions.md
+++ b/docs/migration-from-stream-chat-go/04-messages-and-reactions.md
@@ -258,10 +258,10 @@ func main() {
 	resp, err := client.Chat().UpdateMessagePartial(ctx, "message-id",
 		&getstream.UpdateMessagePartialRequest{
 			Set: map[string]any{
-				"priority": "high",
-				"status":   "reviewed",
+				"text":   "New text",
+				"pinned": true,
 			},
-			Unset:  []string{"old_field"},
+			Unset:  []string{"attachments"},
 			UserID: getstream.PtrTo("user-123"),
 		})
 }


### PR DESCRIPTION
The `After` snippet in `04-messages-and-reactions.md` used different `Set`/`Unset` keys (`priority`/`status`, `old_field`) than the `Before` snippet (`text`/`pinned`, `attachments`), so it no longer read as the same operation migrated. This aligns the `After` keys to the `Before` so the example is a faithful before/after.

Found while building an AI migration skill that treats this guide as the source of truth.