### PR TITLE
fix: name the HTTP status when the error body is not JSON

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -252,8 +252,11 @@ func TestBuildAPIError_UnparseableBodyPath(t *testing.T) {
 	if got.Code != 0 {
 		t.Errorf("Code = %d, want 0 for unparseable", got.Code)
 	}
-	if got.Message != "failed to parse error response" {
+	if got.Message != "failed to parse error response: unexpected server response code 500" {
 		t.Errorf("Message = %q, want canonical unparseable text", got.Message)
+	}
+	if got.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want the transport status preserved", got.StatusCode)
 	}
 	if got.RawResponseBody != body {
 		t.Errorf("RawResponseBody = %q, want raw body preserved", got.RawResponseBody)

--- a/http.go
+++ b/http.go
@@ -131,8 +131,11 @@ func buildAPIError(resp *http.Response, body []byte) *StreamError {
 
 	if len(body) > 0 {
 		if err := json.Unmarshal(body, apiErr); err != nil {
+			// A failed Unmarshal can still have assigned fields before it errored,
+			// so restore the transport status rather than trust the partial parse.
+			apiErr.StatusCode = resp.StatusCode
 			apiErr.Code = 0
-			apiErr.Message = "failed to parse error response"
+			apiErr.Message = fmt.Sprintf("failed to parse error response: unexpected server response code %d", resp.StatusCode)
 			apiErr.ExceptionFields = map[string]string{}
 			apiErr.Unrecoverable = false
 			apiErr.cause = stackWrap(err, "parse api error response")


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-4641/generated-sdks-report-the-http-status-when-the-error-body-is-not-json

## Summary
When an error body is not JSON, the SDK reported only the parse failure and hid the HTTP status. A customer saw `failed to parse error response` for a 503 that the edge proxy returned as plain text, plus a JSON parse stack trace, and could not tell which status they got. `StreamError.Message` now appends the status: `failed to parse error response: unexpected server response code 503`. `StatusCode`, `RawResponseBody` and the parse cause do not change.

The old text is still the prefix of the new message, so prefix matching and substring matching on it both keep working.

Second fix in the same branch: `json.Unmarshal` can assign fields before it errors, so a half-parsed body could leave `StatusCode` wrong on this path. The transport status is now restored.

## Verification
- `go test -short -race ./...`: pass.
- `go mod tidy`: no change to `go.mod` or `go.sum`.
- `golangci-lint run ./...`: same 24 pre-existing issues as the base commit, none at the changed lines.
