### PR TITLE
feat: add other_media to ModerationPayload (v4)

### DIFF
--- a/models.go
+++ b/models.go
@@ -8260,15 +8260,18 @@ func (e *ModerationMarkReviewedEvent) GetEventType() string {
 }
 
 type ModerationPayload struct {
-	Audios           []string          `json:"audios,omitempty"`
-	ImageOrderedKeys []string          `json:"image_ordered_keys,omitempty"`
-	Images           []string          `json:"images,omitempty"`
-	TextOrderedKeys  []string          `json:"text_ordered_keys,omitempty"`
-	Texts            []string          `json:"texts,omitempty"`
-	Videos           []string          `json:"videos,omitempty"`
-	Custom           map[string]any    `json:"custom,omitempty"`
-	ImageIds         map[string]string `json:"image_ids,omitempty"`
-	TextIds          map[string]string `json:"text_ids,omitempty"`
+	Audios           []string `json:"audios,omitempty"`
+	ImageOrderedKeys []string `json:"image_ordered_keys,omitempty"`
+	Images           []string `json:"images,omitempty"`
+	// OtherMedia carries media URLs from attachments outside the typed lists
+	// (custom attachment types like GIF pickers).
+	OtherMedia      []string          `json:"other_media,omitempty"`
+	TextOrderedKeys []string          `json:"text_ordered_keys,omitempty"`
+	Texts           []string          `json:"texts,omitempty"`
+	Videos          []string          `json:"videos,omitempty"`
+	Custom          map[string]any    `json:"custom,omitempty"`
+	ImageIds        map[string]string `json:"image_ids,omitempty"`
+	TextIds         map[string]string `json:"text_ids,omitempty"`
 }
 
 // Content payload for moderation


### PR DESCRIPTION
## Summary
Adds `other_media` to `ModerationPayload` on the v4 line (branched from `v4.2.2`): media URLs from attachments outside the typed `images`/`videos`/`audios` lists (custom attachment types like GIF pickers). The chat backend added this field for GIF flood detection (GetStream/chat#15694) and needs the SDK to carry it on `/api/v2/moderation/check`.

Note: branched from the `v4.2.2` tag since `main` is now `/v5` — needs a `v4.2.3` tag after merge (and the same one-line field on the v5 line, which codegen will pick up from the updated OpenAPI spec anyway).

## Related PRs
- Chat: https://github.com/GetStream/chat/pull/15694

🤖 Generated with [Claude Code](https://claude.com/claude-code)